### PR TITLE
Long-press haptics

### DIFF
--- a/app/src/main/java/helium314/keyboard/event/HapticEvent.kt
+++ b/app/src/main/java/helium314/keyboard/event/HapticEvent.kt
@@ -1,6 +1,5 @@
 package helium314.keyboard.event
 
-import android.os.Build
 import android.view.HapticFeedbackConstants
 
 enum class HapticEvent(@JvmField val feedbackConstant: Int, @JvmField val allowCustomDuration: Boolean) {
@@ -24,14 +23,7 @@ enum class HapticEvent(@JvmField val feedbackConstant: Int, @JvmField val allowC
 //        },
 //        ?
 //    ),
-    GESTURE_MOVE(
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
-            HapticFeedbackConstants.TEXT_HANDLE_MOVE
-        } else {
-            HapticFeedbackConstants.CLOCK_TICK
-        },
-        false
-    ),
+    GESTURE_MOVE(HapticFeedbackConstants.CLOCK_TICK, false),
 //    GESTURE_END(
 //        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
 //            HapticFeedbackConstants.GESTURE_END

--- a/app/src/main/java/helium314/keyboard/event/HapticEvent.kt
+++ b/app/src/main/java/helium314/keyboard/event/HapticEvent.kt
@@ -1,0 +1,32 @@
+package helium314.keyboard.event
+
+import android.view.HapticFeedbackConstants
+
+enum class HapticEvent(@JvmField val feedbackConstant: Int) {
+    NO_HAPTICS(HapticFeedbackConstants.NO_HAPTICS),
+    KEY_PRESS(HapticFeedbackConstants.KEYBOARD_TAP),
+//    KEY_RELEASE(
+//        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+//            HapticFeedbackConstants.KEYBOARD_RELEASE
+//        } else {
+//            HapticFeedbackConstants.?
+//        }
+//    ),
+    KEY_LONG_PRESS(HapticFeedbackConstants.LONG_PRESS),
+//    KEY_REPEAT(HapticFeedbackConstants.?),
+//    GESTURE_START(
+//        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+//            HapticFeedbackConstants.GESTURE_START
+//        } else {
+//            HapticFeedbackConstants.?
+//        }
+//    ),
+    GESTURE_MOVE(HapticFeedbackConstants.CLOCK_TICK),
+//    GESTURE_END(
+//        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+//            HapticFeedbackConstants.GESTURE_END
+//        } else {
+//            HapticFeedbackConstants.?
+//        }
+//    );
+}

--- a/app/src/main/java/helium314/keyboard/event/HapticEvent.kt
+++ b/app/src/main/java/helium314/keyboard/event/HapticEvent.kt
@@ -2,31 +2,34 @@ package helium314.keyboard.event
 
 import android.view.HapticFeedbackConstants
 
-enum class HapticEvent(@JvmField val feedbackConstant: Int) {
-    NO_HAPTICS(HapticFeedbackConstants.NO_HAPTICS),
-    KEY_PRESS(HapticFeedbackConstants.KEYBOARD_TAP),
+enum class HapticEvent(@JvmField val feedbackConstant: Int, @JvmField val allowCustomDuration: Boolean) {
+    NO_HAPTICS(HapticFeedbackConstants.NO_HAPTICS, false),
+    KEY_PRESS(HapticFeedbackConstants.KEYBOARD_TAP, true),
 //    KEY_RELEASE(
 //        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
 //            HapticFeedbackConstants.KEYBOARD_RELEASE
 //        } else {
 //            HapticFeedbackConstants.?
-//        }
+//        },
+//        ?
 //    ),
-    KEY_LONG_PRESS(HapticFeedbackConstants.LONG_PRESS),
-//    KEY_REPEAT(HapticFeedbackConstants.?),
+    KEY_LONG_PRESS(HapticFeedbackConstants.LONG_PRESS, true),
+//    KEY_REPEAT(HapticFeedbackConstants.?, ?),
 //    GESTURE_START(
 //        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
 //            HapticFeedbackConstants.GESTURE_START
 //        } else {
 //            HapticFeedbackConstants.?
-//        }
+//        },
+//        ?
 //    ),
-    GESTURE_MOVE(HapticFeedbackConstants.CLOCK_TICK),
+    GESTURE_MOVE(HapticFeedbackConstants.CLOCK_TICK, false),
 //    GESTURE_END(
 //        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
 //            HapticFeedbackConstants.GESTURE_END
 //        } else {
 //            HapticFeedbackConstants.?
-//        }
-//    );
+//        },
+//        ?
+//    )
 }

--- a/app/src/main/java/helium314/keyboard/event/HapticEvent.kt
+++ b/app/src/main/java/helium314/keyboard/event/HapticEvent.kt
@@ -1,5 +1,6 @@
 package helium314.keyboard.event
 
+import android.os.Build
 import android.view.HapticFeedbackConstants
 
 enum class HapticEvent(@JvmField val feedbackConstant: Int, @JvmField val allowCustomDuration: Boolean) {
@@ -23,7 +24,14 @@ enum class HapticEvent(@JvmField val feedbackConstant: Int, @JvmField val allowC
 //        },
 //        ?
 //    ),
-    GESTURE_MOVE(HapticFeedbackConstants.CLOCK_TICK, false),
+    GESTURE_MOVE(
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            HapticFeedbackConstants.TEXT_HANDLE_MOVE
+        } else {
+            HapticFeedbackConstants.CLOCK_TICK
+        },
+        false
+    ),
 //    GESTURE_END(
 //        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
 //            HapticFeedbackConstants.GESTURE_END

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListener.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListener.java
@@ -24,7 +24,7 @@ public interface KeyboardActionListener {
      * @param hapticEvent the type of haptic feedback to perform.
      */
     void onPressKey(int primaryCode, int repeatCount, boolean isSinglePointer, HapticEvent hapticEvent);
-    void onLongPressKey(int primaryCode);
+    void onLongPressKey();
 
     /**
      * Called when the user releases a key. This is sent after the {@link #onCodeInput} is called.
@@ -127,7 +127,7 @@ public interface KeyboardActionListener {
         @Override
         public void onPressKey(int primaryCode, int repeatCount, boolean isSinglePointer, HapticEvent hapticEvent) {}
         @Override
-        public void onLongPressKey(int primaryCode) {}
+        public void onLongPressKey() {}
         @Override
         public void onReleaseKey(int primaryCode, boolean withSliding) {}
         @Override

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListener.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListener.java
@@ -8,6 +8,7 @@ package helium314.keyboard.keyboard;
 
 import android.view.KeyEvent;
 
+import helium314.keyboard.event.HapticEvent;
 import helium314.keyboard.latin.common.Constants;
 import helium314.keyboard.latin.common.InputPointers;
 
@@ -20,8 +21,10 @@ public interface KeyboardActionListener {
      *            the value will be zero.
      * @param repeatCount how many times the key was repeated. Zero if it is the first press.
      * @param isSinglePointer true if pressing has occurred while no other key is being pressed.
+     * @param hapticEvent the type of haptic feedback to perform.
      */
-    void onPressKey(int primaryCode, int repeatCount, boolean isSinglePointer);
+    void onPressKey(int primaryCode, int repeatCount, boolean isSinglePointer, HapticEvent hapticEvent);
+    void onLongPressKey(int primaryCode);
 
     /**
      * Called when the user releases a key. This is sent after the {@link #onCodeInput} is called.
@@ -122,7 +125,9 @@ public interface KeyboardActionListener {
 
     class Adapter implements KeyboardActionListener {
         @Override
-        public void onPressKey(int primaryCode, int repeatCount, boolean isSinglePointer) {}
+        public void onPressKey(int primaryCode, int repeatCount, boolean isSinglePointer, HapticEvent hapticEvent) {}
+        @Override
+        public void onLongPressKey(int primaryCode) {}
         @Override
         public void onReleaseKey(int primaryCode, boolean withSliding) {}
         @Override

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
@@ -69,7 +69,7 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
         latinIME.hapticAndAudioFeedback(primaryCode, repeatCount, hapticEvent)
     }
 
-    override fun onLongPressKey(primaryCode: Int) {
+    override fun onLongPressKey() {
         audioAndHapticFeedbackManager.performHapticFeedback(keyboardSwitcher.visibleKeyboardView, HapticEvent.KEY_LONG_PRESS)
     }
 

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
@@ -296,7 +296,7 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
                 }
                 return true
             }
-            gestureMoveForwardHaptics()
+            gestureMoveForwardHaptics(text.isNotEmpty())
         }
 
         // the shortcut below causes issues due to horrible handling of text fields by Firefox and forks
@@ -351,8 +351,8 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
         }
     }
 
-    private fun gestureMoveForwardHaptics() {
-        if (!connection.noTextAfterCursor()) {
+    private fun gestureMoveForwardHaptics(hasTextAfterCursor: Boolean? = null) {
+        if (hasTextAfterCursor ?: !connection.noTextAfterCursor()) {
             performHapticFeedback(HapticEvent.GESTURE_MOVE)
         }
     }

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
@@ -66,11 +66,12 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
     override fun onPressKey(primaryCode: Int, repeatCount: Int, isSinglePointer: Boolean, hapticEvent: HapticEvent) {
         adjustMetaState(primaryCode, false)
         keyboardSwitcher.onPressKey(primaryCode, isSinglePointer, latinIME.currentAutoCapsState, latinIME.currentRecapitalizeState)
+        // we need to use LatinIME for handling of key-down audio and haptics
         latinIME.hapticAndAudioFeedback(primaryCode, repeatCount, hapticEvent)
     }
 
     override fun onLongPressKey() {
-        audioAndHapticFeedbackManager.performHapticFeedback(keyboardSwitcher.visibleKeyboardView, HapticEvent.KEY_LONG_PRESS)
+        performHapticFeedback(HapticEvent.KEY_LONG_PRESS)
     }
 
     override fun onReleaseKey(primaryCode: Int, withSliding: Boolean) {
@@ -346,14 +347,18 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
 
     private fun gestureMoveBackHaptics() {
         if (connection.canDeleteCharacters()) {
-            audioAndHapticFeedbackManager.performHapticFeedback(keyboardSwitcher.visibleKeyboardView, HapticEvent.GESTURE_MOVE)
+            performHapticFeedback(HapticEvent.GESTURE_MOVE)
         }
     }
 
     private fun gestureMoveForwardHaptics() {
         if (!connection.noTextAfterCursor()) {
-            audioAndHapticFeedbackManager.performHapticFeedback(keyboardSwitcher.visibleKeyboardView, HapticEvent.GESTURE_MOVE)
+            performHapticFeedback(HapticEvent.GESTURE_MOVE)
         }
+    }
+
+    private fun performHapticFeedback(hapticEvent: HapticEvent) {
+        audioAndHapticFeedbackManager.performHapticFeedback(keyboardSwitcher.visibleKeyboardView, hapticEvent)
     }
 
     private fun getHardwareKeyEventDecoder(deviceId: Int): HardwareEventDecoder {

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
@@ -37,6 +37,7 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
 
     private val keyboardSwitcher = KeyboardSwitcher.getInstance()
     private val settings = Settings.getInstance()
+    private val audioAndHapticFeedbackManager = AudioAndHapticFeedbackManager.getInstance()
     private var metaState = 0 // is this enough, or are there threading issues with the different PointerTrackers?
 
     // language slide state
@@ -115,8 +116,8 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
 
     override fun onCodeInput(primaryCode: Int, x: Int, y: Int, isKeyRepeat: Boolean) {
         when (primaryCode) {
-            KeyCode.TOGGLE_AUTOCORRECT -> return Settings.getInstance().toggleAutoCorrect()
-            KeyCode.TOGGLE_INCOGNITO_MODE -> return Settings.getInstance().toggleAlwaysIncognitoMode()
+            KeyCode.TOGGLE_AUTOCORRECT -> return settings.toggleAutoCorrect()
+            KeyCode.TOGGLE_INCOGNITO_MODE -> return settings.toggleAlwaysIncognitoMode()
         }
         val mkv = keyboardSwitcher.mainKeyboardView
 
@@ -182,7 +183,7 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
     }
 
     override fun toggleNumpad(withSliding: Boolean, forceReturnToAlpha: Boolean): Boolean {
-        KeyboardSwitcher.getInstance().toggleNumpad(withSliding, latinIME.currentAutoCapsState, latinIME.currentRecapitalizeState, forceReturnToAlpha)
+        keyboardSwitcher.toggleNumpad(withSliding, latinIME.currentAutoCapsState, latinIME.currentRecapitalizeState, forceReturnToAlpha)
         return true
     }
 
@@ -192,7 +193,7 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
         val actualSteps = actualSteps(steps)
         val start = connection.expectedSelectionStart + actualSteps
         if (start > end) return
-        AudioAndHapticFeedbackManager.getInstance().performHapticFeedback(keyboardSwitcher.visibleKeyboardView, HapticEvent.GESTURE_MOVE)
+        audioAndHapticFeedbackManager.performHapticFeedback(keyboardSwitcher.visibleKeyboardView, HapticEvent.GESTURE_MOVE)
         connection.setSelection(start, end)
     }
 
@@ -249,13 +250,13 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
         }
         if (steps > 0) subtypeSwitchCount++ else subtypeSwitchCount--
 
-        KeyboardSwitcher.getInstance().switchToSubtype(newSubtype)
+        keyboardSwitcher.switchToSubtype(newSubtype)
         return true
     }
 
     private fun onMoveCursorVertically(steps: Int): Boolean {
         if (steps == 0) return false
-        AudioAndHapticFeedbackManager.getInstance().performHapticFeedback(keyboardSwitcher.visibleKeyboardView, HapticEvent.GESTURE_MOVE)
+        audioAndHapticFeedbackManager.performHapticFeedback(keyboardSwitcher.visibleKeyboardView, HapticEvent.GESTURE_MOVE)
         val code = if (steps < 0) KeyCode.ARROW_UP else KeyCode.ARROW_DOWN
         onCodeInput(code, Constants.NOT_A_COORDINATE, Constants.NOT_A_COORDINATE, false)
         return true
@@ -263,7 +264,7 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
 
     private fun onMoveCursorHorizontally(rawSteps: Int): Boolean {
         if (rawSteps == 0) return false
-        AudioAndHapticFeedbackManager.getInstance().performHapticFeedback(keyboardSwitcher.visibleKeyboardView, HapticEvent.GESTURE_MOVE)
+        audioAndHapticFeedbackManager.performHapticFeedback(keyboardSwitcher.visibleKeyboardView, HapticEvent.GESTURE_MOVE)
         // for RTL languages we want to invert pointer movement
         val steps = if (RichInputMethodManager.getInstance().currentSubtype.isRtlSubtype) -rawSteps else rawSteps
         val moveSteps: Int

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
@@ -282,6 +282,9 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
                 repeat(-steps) {
                     onCodeInput(KeyCode.ARROW_LEFT, Constants.NOT_A_COORDINATE, Constants.NOT_A_COORDINATE, false)
                 }
+                if (text.isNotEmpty()) {
+                    gestureMoveBackHaptics()
+                }
                 return true
             }
             gestureMoveBackHaptics()
@@ -293,6 +296,9 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
                 // we fall back to virtually pressing the left/right key one or more times instead
                 repeat(steps) {
                     onCodeInput(KeyCode.ARROW_RIGHT, Constants.NOT_A_COORDINATE, Constants.NOT_A_COORDINATE, false)
+                }
+                if (text.isNotEmpty()) {
+                    gestureMoveForwardHaptics(true)
                 }
                 return true
             }

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
@@ -70,7 +70,7 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
     }
 
     override fun onLongPressKey(primaryCode: Int) {
-        latinIME.hapticAndAudioFeedback(primaryCode, 0, HapticEvent.KEY_LONG_PRESS)
+        audioAndHapticFeedbackManager.performHapticFeedback(keyboardSwitcher.visibleKeyboardView, HapticEvent.KEY_LONG_PRESS)
     }
 
     override fun onReleaseKey(primaryCode: Int, withSliding: Boolean) {

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -17,6 +17,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.util.TypedValueCompat;
 
+import helium314.keyboard.event.HapticEvent;
 import helium314.keyboard.keyboard.internal.BatchInputArbiter;
 import helium314.keyboard.keyboard.internal.BatchInputArbiter.BatchInputArbiterListener;
 import helium314.keyboard.keyboard.internal.BogusMoveEventDetector;
@@ -288,7 +289,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             return false;
         }
         if (key.isEnabled()) {
-            sListener.onPressKey(key.getCode(), repeatCount, getActivePointerTrackerCount() == 1);
+            sListener.onPressKey(key.getCode(), repeatCount, getActivePointerTrackerCount() == 1, HapticEvent.KEY_PRESS);
             final boolean keyboardLayoutHasBeenChanged = mKeyboardLayoutHasBeenChanged;
             mKeyboardLayoutHasBeenChanged = false;
             sTimerProxy.startTypingStateTimer(key);
@@ -1128,15 +1129,16 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         if (key == null) {
             return;
         }
+        final int code = key.getCode();
+        sListener.onLongPressKey(code);
         if (key.hasNoPanelAutoPopupKey()) {
             cancelKeyTracking();
             final int popupKeyCode = key.getPopupKeys()[0].mCode;
-            sListener.onPressKey(popupKeyCode, 0, true);
+            sListener.onPressKey(popupKeyCode, 0, true, HapticEvent.NO_HAPTICS);
             sListener.onCodeInput(popupKeyCode, Constants.NOT_A_COORDINATE, Constants.NOT_A_COORDINATE, false);
             sListener.onReleaseKey(popupKeyCode, false);
             return;
         }
-        final int code = key.getCode();
         if (code == KeyCode.LANGUAGE_SWITCH
                 || (code == Constants.CODE_SPACE && key.getPopupKeys() == null && Settings.getValues().mSpaceForLangChange)
         ) {

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -1129,8 +1129,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         if (key == null) {
             return;
         }
-        final int code = key.getCode();
-        sListener.onLongPressKey(code);
+        sListener.onLongPressKey();
         if (key.hasNoPanelAutoPopupKey()) {
             cancelKeyTracking();
             final int popupKeyCode = key.getPopupKeys()[0].mCode;
@@ -1139,6 +1138,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             sListener.onReleaseKey(popupKeyCode, false);
             return;
         }
+        final int code = key.getCode();
         if (code == KeyCode.LANGUAGE_SWITCH
                 || (code == Constants.CODE_SPACE && key.getPopupKeys() == null && Settings.getValues().mSpaceForLangChange)
         ) {

--- a/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardHistoryView.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardHistoryView.kt
@@ -210,7 +210,7 @@ class ClipboardHistoryView @JvmOverloads constructor(
     override fun onLongClick(view: View): Boolean {
         val tag = view.tag
         if (tag is ToolbarKey) {
-            AudioAndHapticFeedbackManager.getInstance().performHapticAndAudioFeedback(Constants.NOT_A_CODE, this, HapticEvent.KEY_LONG_PRESS)
+            AudioAndHapticFeedbackManager.getInstance().performHapticAndAudioFeedback(KeyCode.NOT_SPECIFIED, this, HapticEvent.KEY_LONG_PRESS)
             val longClickCode = getCodeForToolbarKeyLongClick(tag)
             if (longClickCode != KeyCode.UNSPECIFIED) {
                 keyboardActionListener.onCodeInput(

--- a/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardHistoryView.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardHistoryView.kt
@@ -198,7 +198,7 @@ class ClipboardHistoryView @JvmOverloads constructor(
     override fun onClick(view: View) {
         val tag = view.tag
         if (tag is ToolbarKey) {
-            AudioAndHapticFeedbackManager.getInstance().performHapticAndAudioFeedback(KeyCode.NOT_SPECIFIED, this)
+            AudioAndHapticFeedbackManager.getInstance().performHapticAndAudioFeedback(KeyCode.NOT_SPECIFIED, this, HapticEvent.KEY_PRESS)
             val code = getCodeForToolbarKey(tag)
             if (code != KeyCode.UNSPECIFIED) {
                 keyboardActionListener.onCodeInput(code, Constants.NOT_A_COORDINATE, Constants.NOT_A_COORDINATE, false)
@@ -210,7 +210,7 @@ class ClipboardHistoryView @JvmOverloads constructor(
     override fun onLongClick(view: View): Boolean {
         val tag = view.tag
         if (tag is ToolbarKey) {
-            AudioAndHapticFeedbackManager.getInstance().performHapticAndAudioFeedback(Constants.NOT_A_CODE, this)
+            AudioAndHapticFeedbackManager.getInstance().performHapticAndAudioFeedback(Constants.NOT_A_CODE, this, HapticEvent.KEY_LONG_PRESS)
             val longClickCode = getCodeForToolbarKeyLongClick(tag)
             if (longClickCode != KeyCode.UNSPECIFIED) {
                 keyboardActionListener.onCodeInput(

--- a/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardHistoryView.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardHistoryView.kt
@@ -13,6 +13,7 @@ import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
+import helium314.keyboard.event.HapticEvent
 import helium314.keyboard.keyboard.KeyboardActionListener
 import helium314.keyboard.keyboard.KeyboardId
 import helium314.keyboard.keyboard.KeyboardLayoutSet
@@ -222,7 +223,7 @@ class ClipboardHistoryView @JvmOverloads constructor(
     }
 
     override fun onKeyDown(clipId: Long) {
-        keyboardActionListener.onPressKey(KeyCode.NOT_SPECIFIED, 0, true)
+        keyboardActionListener.onPressKey(KeyCode.NOT_SPECIFIED, 0, true, HapticEvent.KEY_PRESS)
     }
 
     override fun onKeyUp(clipId: Long) {

--- a/app/src/main/java/helium314/keyboard/keyboard/emoji/EmojiPalettesView.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/emoji/EmojiPalettesView.java
@@ -25,6 +25,8 @@ import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.viewpager2.widget.ViewPager2;
+
+import helium314.keyboard.event.HapticEvent;
 import helium314.keyboard.keyboard.Key;
 import helium314.keyboard.keyboard.Keyboard;
 import helium314.keyboard.keyboard.KeyboardActionListener;
@@ -272,7 +274,7 @@ public final class EmojiPalettesView extends LinearLayout
     public void onClick(View v) {
         final Object tag = v.getTag();
         if (tag instanceof Long) {
-            AudioAndHapticFeedbackManager.getInstance().performHapticAndAudioFeedback(KeyCode.NOT_SPECIFIED, this);
+            AudioAndHapticFeedbackManager.getInstance().performHapticAndAudioFeedback(KeyCode.NOT_SPECIFIED, this, HapticEvent.KEY_PRESS);
             final int categoryId = ((Long) tag).intValue();
             if (categoryId != mEmojiCategory.getCurrentCategoryId()) {
                 setCurrentCategoryId(categoryId, false);
@@ -288,7 +290,7 @@ public final class EmojiPalettesView extends LinearLayout
     @Override
     public void onPressKey(final Key key) {
         final int code = key.getCode();
-        mKeyboardActionListener.onPressKey(code, 0, true);
+        mKeyboardActionListener.onPressKey(code, 0, true, HapticEvent.KEY_PRESS);
     }
 
     /**

--- a/app/src/main/java/helium314/keyboard/latin/AudioAndHapticFeedbackManager.java
+++ b/app/src/main/java/helium314/keyboard/latin/AudioAndHapticFeedbackManager.java
@@ -99,7 +99,7 @@ public final class AudioAndHapticFeedbackManager {
         if (!mSettingsValues.mVibrateOn || (mDoNotDisturb && !mSettingsValues.mVibrateInDndMode)) {
             return;
         }
-        if (mSettingsValues.mKeypressVibrationDuration >= 0) {
+        if (hapticEvent.allowCustomDuration && mSettingsValues.mKeypressVibrationDuration >= 0) {
             vibrate(mSettingsValues.mKeypressVibrationDuration);
             return;
         }

--- a/app/src/main/java/helium314/keyboard/latin/AudioAndHapticFeedbackManager.java
+++ b/app/src/main/java/helium314/keyboard/latin/AudioAndHapticFeedbackManager.java
@@ -79,14 +79,14 @@ public final class AudioAndHapticFeedbackManager {
     }
 
     public void performAudioFeedback(final int code, final HapticEvent hapticEvent) {
-        if (hapticEvent != HapticEvent.KEY_PRESS) {
-            return;
-        }
         // if mAudioManager is null, we can't play a sound anyway, so return
         if (mAudioManager == null) {
             return;
         }
         if (!mSoundOn) {
+            return;
+        }
+        if (hapticEvent != HapticEvent.KEY_PRESS) {
             return;
         }
         final int sound = switch (code) {

--- a/app/src/main/java/helium314/keyboard/latin/AudioAndHapticFeedbackManager.java
+++ b/app/src/main/java/helium314/keyboard/latin/AudioAndHapticFeedbackManager.java
@@ -57,7 +57,7 @@ public final class AudioAndHapticFeedbackManager {
         final HapticEvent hapticEvent
     ) {
         performHapticFeedback(viewToPerformHapticFeedbackOn, hapticEvent);
-        performAudioFeedback(code);
+        performAudioFeedback(code, hapticEvent);
     }
 
     public boolean hasVibrator() {
@@ -78,7 +78,10 @@ public final class AudioAndHapticFeedbackManager {
         return mAudioManager.getRingerMode() == AudioManager.RINGER_MODE_NORMAL;
     }
 
-    public void performAudioFeedback(final int code) {
+    public void performAudioFeedback(final int code, final HapticEvent hapticEvent) {
+        if (hapticEvent != HapticEvent.KEY_PRESS) {
+            return;
+        }
         // if mAudioManager is null, we can't play a sound anyway, so return
         if (mAudioManager == null) {
             return;

--- a/app/src/main/java/helium314/keyboard/latin/AudioAndHapticFeedbackManager.java
+++ b/app/src/main/java/helium314/keyboard/latin/AudioAndHapticFeedbackManager.java
@@ -12,6 +12,7 @@ import android.os.Vibrator;
 import android.view.HapticFeedbackConstants;
 import android.view.View;
 
+import helium314.keyboard.event.HapticEvent;
 import helium314.keyboard.keyboard.internal.keyboard_parser.floris.KeyCode;
 import helium314.keyboard.latin.common.Constants;
 import helium314.keyboard.latin.settings.SettingsValues;
@@ -51,9 +52,12 @@ public final class AudioAndHapticFeedbackManager {
         mVibrator = (Vibrator) context.getSystemService(Context.VIBRATOR_SERVICE);
     }
 
-    public void performHapticAndAudioFeedback(final int code,
-            final View viewToPerformHapticFeedbackOn) {
-        performHapticFeedback(viewToPerformHapticFeedbackOn);
+    public void performHapticAndAudioFeedback(
+        final int code,
+        final View viewToPerformHapticFeedbackOn,
+        final HapticEvent hapticEvent
+    ) {
+        performHapticFeedback(viewToPerformHapticFeedbackOn, hapticEvent);
         performAudioFeedback(code);
     }
 
@@ -92,7 +96,7 @@ public final class AudioAndHapticFeedbackManager {
         mAudioManager.playSoundEffect(sound, mSettingsValues.mKeypressSoundVolume);
     }
 
-    public void performHapticFeedback(final View viewToPerformHapticFeedbackOn) {
+    public void performHapticFeedback(final View viewToPerformHapticFeedbackOn, final HapticEvent hapticEvent) {
         if (!mSettingsValues.mVibrateOn || (mDoNotDisturb && !mSettingsValues.mVibrateInDndMode)) {
             return;
         }
@@ -107,7 +111,7 @@ public final class AudioAndHapticFeedbackManager {
         // Go ahead with the system default
         if (viewToPerformHapticFeedbackOn != null) {
             viewToPerformHapticFeedbackOn.performHapticFeedback(
-                    HapticFeedbackConstants.KEYBOARD_TAP,
+                    hapticEvent.feedbackConstant,
                     HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING);
         }
     }

--- a/app/src/main/java/helium314/keyboard/latin/AudioAndHapticFeedbackManager.java
+++ b/app/src/main/java/helium314/keyboard/latin/AudioAndHapticFeedbackManager.java
@@ -33,7 +33,6 @@ public final class AudioAndHapticFeedbackManager {
 
     private static final AudioAndHapticFeedbackManager sInstance =
             new AudioAndHapticFeedbackManager();
-    private long mLastVibrationMillis;
 
     public static AudioAndHapticFeedbackManager getInstance() {
         return sInstance;
@@ -100,10 +99,6 @@ public final class AudioAndHapticFeedbackManager {
         if (!mSettingsValues.mVibrateOn || (mDoNotDisturb && !mSettingsValues.mVibrateInDndMode)) {
             return;
         }
-
-        if (System.currentTimeMillis() < mLastVibrationMillis + 100) return;
-        mLastVibrationMillis = System.currentTimeMillis();
-
         if (mSettingsValues.mKeypressVibrationDuration >= 0) {
             vibrate(mSettingsValues.mKeypressVibrationDuration);
             return;

--- a/app/src/main/java/helium314/keyboard/latin/AudioAndHapticFeedbackManager.java
+++ b/app/src/main/java/helium314/keyboard/latin/AudioAndHapticFeedbackManager.java
@@ -102,6 +102,10 @@ public final class AudioAndHapticFeedbackManager {
         if (!mSettingsValues.mVibrateOn || (mDoNotDisturb && !mSettingsValues.mVibrateInDndMode)) {
             return;
         }
+        if (hapticEvent == HapticEvent.NO_HAPTICS) {
+            // Avoid surprises with the handling of HapticFeedbackConstants.NO_HAPTICS
+            return;
+        }
         if (hapticEvent.allowCustomDuration && mSettingsValues.mKeypressVibrationDuration >= 0) {
             vibrate(mSettingsValues.mKeypressVibrationDuration);
             return;

--- a/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
+++ b/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
@@ -13,6 +13,7 @@ import android.view.inputmethod.EditorInfo
 import androidx.core.view.isGone
 import kotlinx.serialization.json.Json
 import helium314.keyboard.compat.ClipboardManagerCompat
+import helium314.keyboard.event.HapticEvent
 import helium314.keyboard.keyboard.internal.keyboard_parser.floris.KeyCode
 import helium314.keyboard.latin.common.ColorType
 import helium314.keyboard.latin.common.isValidNumber
@@ -206,7 +207,7 @@ class ClipboardHistoryManager(
         textView.setOnClickListener {
             dontShowCurrentSuggestion = true
             latinIME.onTextInput(content.toString())
-            AudioAndHapticFeedbackManager.getInstance().performHapticAndAudioFeedback(KeyCode.NOT_SPECIFIED, it)
+            AudioAndHapticFeedbackManager.getInstance().performHapticAndAudioFeedback(KeyCode.NOT_SPECIFIED, it, HapticEvent.KEY_PRESS)
             binding.root.isGone = true
         }
         val closeButton = binding.clipboardSuggestionClose

--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -43,6 +43,7 @@ import android.view.inputmethod.InputMethodSubtype;
 import helium314.keyboard.accessibility.AccessibilityUtils;
 import helium314.keyboard.compat.ConfigurationCompatKt;
 import helium314.keyboard.compat.EditorInfoCompatUtils;
+import helium314.keyboard.event.HapticEvent;
 import helium314.keyboard.keyboard.KeyboardActionListener;
 import helium314.keyboard.keyboard.KeyboardActionListenerImpl;
 import helium314.keyboard.keyboard.internal.KeyboardIconsSet;
@@ -1771,7 +1772,8 @@ public class LatinIME extends InputMethodService implements
         }
     }
 
-    public void hapticAndAudioFeedback(final int code, final int repeatCount) {
+    public void hapticAndAudioFeedback(final int code, final int repeatCount,
+                                       final HapticEvent hapticEvent) {
         final MainKeyboardView keyboardView = mKeyboardSwitcher.getMainKeyboardView();
         if (keyboardView != null && keyboardView.isInDraggingFinger()) {
             // No need to feedback while finger is dragging.
@@ -1799,7 +1801,7 @@ public class LatinIME extends InputMethodService implements
                 AudioAndHapticFeedbackManager.getInstance();
         if (repeatCount == 0) {
             // TODO: Reconsider how to perform haptic feedback when repeating key.
-            feedbackManager.performHapticFeedback(keyboardView);
+            feedbackManager.performHapticFeedback(keyboardView, hapticEvent);
         }
         feedbackManager.performAudioFeedback(code);
     }

--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -1803,7 +1803,7 @@ public class LatinIME extends InputMethodService implements
             // TODO: Reconsider how to perform haptic feedback when repeating key.
             feedbackManager.performHapticFeedback(keyboardView, hapticEvent);
         }
-        feedbackManager.performAudioFeedback(code);
+        feedbackManager.performAudioFeedback(code, hapticEvent);
     }
 
     // Hooks for hardware keyboard

--- a/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.kt
+++ b/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.kt
@@ -29,6 +29,7 @@ import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.core.view.isVisible
 import helium314.keyboard.compat.isDeviceLocked
+import helium314.keyboard.event.HapticEvent
 import helium314.keyboard.keyboard.KeyboardSwitcher
 import helium314.keyboard.keyboard.internal.KeyboardIconsSet
 import helium314.keyboard.keyboard.internal.keyboard_parser.floris.KeyCode
@@ -297,7 +298,7 @@ class SuggestionStripView(context: Context, attrs: AttributeSet?, defStyle: Int)
     }
 
     override fun onClick(view: View) {
-        AudioAndHapticFeedbackManager.getInstance().performHapticAndAudioFeedback(KeyCode.NOT_SPECIFIED, this)
+        AudioAndHapticFeedbackManager.getInstance().performHapticAndAudioFeedback(KeyCode.NOT_SPECIFIED, this, HapticEvent.KEY_PRESS)
         val tag = view.tag
         if (tag is ToolbarKey) {
             val code = getCodeForToolbarKey(tag)
@@ -323,7 +324,7 @@ class SuggestionStripView(context: Context, attrs: AttributeSet?, defStyle: Int)
     }
 
     override fun onLongClick(view: View): Boolean {
-        AudioAndHapticFeedbackManager.getInstance().performHapticAndAudioFeedback(Constants.NOT_A_CODE, this)
+        AudioAndHapticFeedbackManager.getInstance().performHapticAndAudioFeedback(Constants.NOT_A_CODE, this, HapticEvent.KEY_LONG_PRESS)
         if (view.tag is ToolbarKey) {
             onLongClickToolbarKey(view)
             return true

--- a/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.kt
+++ b/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.kt
@@ -324,7 +324,7 @@ class SuggestionStripView(context: Context, attrs: AttributeSet?, defStyle: Int)
     }
 
     override fun onLongClick(view: View): Boolean {
-        AudioAndHapticFeedbackManager.getInstance().performHapticAndAudioFeedback(Constants.NOT_A_CODE, this, HapticEvent.KEY_LONG_PRESS)
+        AudioAndHapticFeedbackManager.getInstance().performHapticFeedback(this, HapticEvent.KEY_LONG_PRESS)
         if (view.tag is ToolbarKey) {
             onLongClickToolbarKey(view)
             return true


### PR DESCRIPTION
We are so back.

This branch closes #1859 by adding long-press haptics to the keyboard.
EDIT: this branch also closes #2021, provided we keep the removal of the haptic cooldown. I came back at a really good time! What a wild coincidence.

**Behavior changes:**
- When key-press vibration is enabled, a long-press vibration will occur when long-pressing a key.
    - Includes keys with pop-up panels.
    - Includes keys with long-press actions like space -> languages, shift -> caps lock, and symbols -> numpad.
    - Does **not** include repeating keys
    - Does **not** include keys that do nothing significant when long-pressed such as symbols-shift or square-root.
- Long-pressing a word in the suggestions strip now uses the "long press" vibration instead of the "key press" one.
    - No longer makes a key-press sound.
- I noticed the change to gesture haptics. I don't like how strong it is, so I reduced the strength to "clock tick." This seems to be in line with my best guess at what Gboard uses. @eranl, what do you think of this?
    - Also made it so those haptics don't happen when the gesture action will do nothing (when we can detect such a thing)
    - Currently, this means they won't happen when doing virtual left/right arrow keys for bad input fields. We can revise this later, but I would want to suppress those virtual keypresses for good input fields before adding haptics to the bad ones. There's currently no easy way to tell the difference, and these revisions have already stretched the scope of this PR.

**Technical notes:**
- I've created an enum class for different types of haptic feedback that can hopefully make extending things like this easier moving forward. You can see I have some commented constants of haptics that could be implemented later.
- There's a special case with the shift -> caps lock long-press. That's the one long-press that did have haptics since it's implemented using a dummy key-press. We want to use the long-press vibration strength, not the key-press one. HapticEvent.NO_HAPTICS is used to ensure this.

p.s.: didn't we want longer long-press duration for the spacebar -> language menu gesture? did that change at some point? it seems to just have the regular duration. i'd prefer 1.5x personally.