### PR TITLE
Setting to split concatenated words

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/Suggest.kt
+++ b/app/src/main/java/helium314/keyboard/latin/Suggest.kt
@@ -113,6 +113,11 @@ class Suggest(private val mDictionaryFacilitator: DictionaryFacilitator) {
                 getSuggestionsInfoListWithDebugInfo(capitalizedTypedWord, suggestionsContainer)
             else suggestionsContainer
 
+        // Detect and suggest corrections for concatenated words with accidental bottom-row key presses
+        if (!resultsArePredictions && typedWordString.length > 4 && Settings.getValues().mSuggestSplitConcatenatedWords) {
+            tryAddConcatenatedWordSuggestions(typedWordString, suggestionsList, firstOccurrenceOfTypedWordInSuggestions)
+        }
+
         val inputStyle = if (resultsArePredictions) {
             if (suggestionResults.mIsBeginningOfSentence) SuggestedWords.INPUT_STYLE_BEGINNING_OF_SENTENCE_PREDICTION
             else SuggestedWords.INPUT_STYLE_PREDICTION
@@ -250,6 +255,57 @@ class Suggest(private val mDictionaryFacilitator: DictionaryFacilitator) {
             }
         }
         return allowsToBeAutoCorrected to hasAutoCorrection
+    }
+
+    /**
+     * Detects concatenated words with accidental bottom-row key presses (c, v, b, n, m)
+     * and adds spaced suggestions if both parts are valid dictionary words.
+     * Example: "hellobthere" -> suggests "hello there"
+     */
+    internal fun tryAddConcatenatedWordSuggestions(
+        typedWord: String,
+        suggestions: ArrayList<SuggestedWordInfo>,
+        firstOccurrenceOfTypedWord: Int
+    ) {
+        if (firstOccurrenceOfTypedWord >= 0) return // typed word is already valid
+
+        val bottomRowChars = setOf('c', 'v', 'b', 'n', 'm')
+        val lowerTypedWord = typedWord.lowercase(mDictionaryFacilitator.mainLocale)
+
+        // Try splitting at each bottom-row character position
+        for (i in 2 until lowerTypedWord.length - 2) { // min 2 chars on each side
+            val char = lowerTypedWord[i]
+            if (char !in bottomRowChars) continue
+
+            // Try splitting at this position (removing the accidental character)
+            val part1 = lowerTypedWord.substring(0, i)
+            val part2 = lowerTypedWord.substring(i + 1)
+
+            if (mDictionaryFacilitator.isValidSpellingWord(part1) &&
+                mDictionaryFacilitator.isValidSpellingWord(part2)) {
+
+                val spacedSuggestion = "$part1 $part2"
+                // Add with high score to make it a prominent suggestion
+                val suggestionInfo = SuggestedWordInfo(
+                    spacedSuggestion,
+                    "",
+                    SuggestedWordInfo.MAX_SCORE - 1, // high score but below typed word
+                    SuggestedWordInfo.KIND_CORRECTION,
+                    Dictionary.DICTIONARY_USER_TYPED,
+                    SuggestedWordInfo.NOT_AN_INDEX,
+                    SuggestedWordInfo.NOT_A_CONFIDENCE
+                )
+
+                // Insert at appropriate position
+                if (!suggestions.any { it.mWord == spacedSuggestion }) {
+                    // If there are already suggestions, insert at position 1 (right after typed word)
+                    // Otherwise just add to the list
+                    val insertPosition = if (suggestions.size > 1) 1 else suggestions.size
+                    suggestions.add(insertPosition, suggestionInfo)
+                }
+                return // only add one spaced suggestion
+            }
+        }
     }
 
     // Retrieves suggestions for the batch input

--- a/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
@@ -63,6 +63,7 @@ object Defaults {
     const val PREF_AUTO_CORRECT_THRESHOLD = 0.185f
     const val PREF_AUTOCORRECT_SHORTCUTS = true
     const val PREF_BACKSPACE_REVERTS_AUTOCORRECT = true
+    const val PREF_SUGGEST_SPLIT_CONCATENATED_WORDS = false
     const val PREF_CENTER_SUGGESTION_TEXT_TO_ENTER = false
     const val PREF_SHOW_SUGGESTIONS = true
     const val PREF_ALWAYS_SHOW_SUGGESTIONS = false

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -75,6 +75,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_AUTO_CORRECT_THRESHOLD = "auto_correct_threshold";
     public static final String PREF_AUTOCORRECT_SHORTCUTS = "autocorrect_shortcuts";
     public static final String PREF_BACKSPACE_REVERTS_AUTOCORRECT = "backspace_reverts_autocorrect";
+    public static final String PREF_SUGGEST_SPLIT_CONCATENATED_WORDS = "suggest_split_concatenated_words";
     public static final String PREF_CENTER_SUGGESTION_TEXT_TO_ENTER = "center_suggestion_text_to_enter";
     public static final String PREF_SHOW_SUGGESTIONS = "show_suggestions";
     public static final String PREF_ALWAYS_SHOW_SUGGESTIONS = "always_show_suggestions";

--- a/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
@@ -143,6 +143,7 @@ public class SettingsValues {
     public final boolean mAutoCorrectEnabled;
     public final float mAutoCorrectionThreshold;
     public final boolean mBackspaceRevertsAutocorrect;
+    public final boolean mSuggestSplitConcatenatedWords;
     public final int mScoreLimitForAutocorrect;
     public final boolean mAutoCorrectShortcuts;
     private final boolean mSuggestionsEnabledPerUserSettings;
@@ -208,6 +209,7 @@ public class SettingsValues {
                 : (mAutoCorrectionThreshold < 0.07 ? 800000 : 950000); // aggressive or modest
         mAutoCorrectShortcuts = prefs.getBoolean(Settings.PREF_AUTOCORRECT_SHORTCUTS, Defaults.PREF_AUTOCORRECT_SHORTCUTS);
         mBackspaceRevertsAutocorrect = prefs.getBoolean(Settings.PREF_BACKSPACE_REVERTS_AUTOCORRECT, Defaults.PREF_BACKSPACE_REVERTS_AUTOCORRECT);
+        mSuggestSplitConcatenatedWords = prefs.getBoolean(Settings.PREF_SUGGEST_SPLIT_CONCATENATED_WORDS, Defaults.PREF_SUGGEST_SPLIT_CONCATENATED_WORDS);
         mBigramPredictionEnabled = prefs.getBoolean(Settings.PREF_BIGRAM_PREDICTIONS, Defaults.PREF_BIGRAM_PREDICTIONS);
         mSuggestPunctuation = prefs.getBoolean(Settings.PREF_SUGGEST_PUNCTUATION, Defaults.PREF_SUGGEST_PUNCTUATION);
         mSuggestClipboardContent = prefs.getBoolean(Settings.PREF_SUGGEST_CLIPBOARD_CONTENT, Defaults.PREF_SUGGEST_CLIPBOARD_CONTENT);

--- a/app/src/main/java/helium314/keyboard/settings/screens/TextCorrectionScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/TextCorrectionScreen.kt
@@ -64,6 +64,7 @@ fun TextCorrectionScreen(
         if (autocorrectEnabled) Settings.PREF_AUTOCORRECT_SHORTCUTS else null,
         if (autocorrectEnabled) Settings.PREF_AUTO_CORRECT_THRESHOLD else null,
         if (autocorrectEnabled) Settings.PREF_BACKSPACE_REVERTS_AUTOCORRECT else null,
+        if (autocorrectEnabled) Settings.PREF_SUGGEST_SPLIT_CONCATENATED_WORDS else null,
         Settings.PREF_AUTO_CAP,
         R.string.settings_category_space,
         Settings.PREF_KEY_USE_DOUBLE_SPACE_PERIOD,
@@ -133,6 +134,11 @@ fun createCorrectionSettings(context: Context) = listOf(
     },
     Setting(context, Settings.PREF_BACKSPACE_REVERTS_AUTOCORRECT, R.string.backspace_reverts_autocorrect) {
         SwitchPreference(it, Defaults.PREF_BACKSPACE_REVERTS_AUTOCORRECT)
+    },
+    Setting(context, Settings.PREF_SUGGEST_SPLIT_CONCATENATED_WORDS,
+        R.string.suggest_split_concatenated_words, R.string.suggest_split_concatenated_words_summary
+    ) {
+        SwitchPreference(it, Defaults.PREF_SUGGEST_SPLIT_CONCATENATED_WORDS)
     },
     Setting(context, Settings.PREF_AUTO_CAP,
         R.string.auto_cap, R.string.auto_cap_summary

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,6 +141,10 @@
     <string name="auto_correct_shortcuts_summary">When enabled shortcuts might be expanded by autocorrect</string>
     <!-- Option to undo auto correction with backspace -->
     <string name="backspace_reverts_autocorrect">Backspace reverts autocorrect</string>
+    <!-- Option to suggest split words when accidentally typing bottom row keys instead of space -->
+    <string name="suggest_split_concatenated_words">Suggest split words</string>
+    <!-- Description for suggest_split_concatenated_words -->
+    <string name="suggest_split_concatenated_words_summary">Suggest space-separated words when c, v, b, n, or m is accidentally typed instead of space</string>
     <!-- Option to disable auto correction. -->
     <string name="auto_correction_threshold_mode_off">Off</string>
     <!-- Option to suggest auto correction suggestions modestly. Auto-corrects only to a word which has small edit distance from typed word. -->


### PR DESCRIPTION
Since using this keyboard a major issue i've found is how easy it is to accidentally write concatenated words where I accidentally press a letter instead of the space bar. I'm constantly writing c, v, b, n, and m (bottom row keys) instead of space leading to words like "hellobthere" or "whatbarenyouvdoingvtonight?"

My proposal is adding a setting which would correct for this specific issue by trying to split unknown words by the trouble keys and testing for dictionary values in the split words. Using a version with this fix works great and my number of mispells and retypes has gone down drastically.

An alternative fix for this is to enlarge the whole keyboard thus increasing padding around the space bar, but it affects ergonomics and what you can read on screen. Another possibility is to enlarge the space bar but that also affects screen size.

This was not an issue with major competing keyboards as I suspect they either correct using their own proprietary models, or they do something similar to this change. I have no intention of using those keyboards so I believe Heliboard should be able to solve the problem. I believe this solution is a better enhancement and provides for a good user experience when enabled.


Not sure what the usual testing is but i confirmed my tests pass against Android platform 35 + OpenJDK 17.0.16