### PR TITLE
Don't autocorrect using capitalized suggestions

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/Suggest.kt
+++ b/app/src/main/java/helium314/keyboard/latin/Suggest.kt
@@ -139,7 +139,8 @@ class Suggest(private val mDictionaryFacilitator: DictionaryFacilitator) {
         }
         val isTypedWordValid = firstOccurrenceOfTypedWordInSuggestions > -1 || (!resultsArePredictions && !allowsToBeAutoCorrected)
         return SuggestedWords(suggestionsList, suggestionResults.mRawSuggestions,
-            typedWordInfo, isTypedWordValid, hasAutoCorrection, false, inputStyle, sequenceNumber)
+            typedWordInfo, isTypedWordValid, hasAutoCorrection && capitalizedTypedWord == wordComposer.typedWord, false, inputStyle,
+            sequenceNumber)
     }
 
     // returns [allowsToBeAutoCorrected, hasAutoCorrection]

--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -584,16 +584,8 @@ public final class InputLogic {
     // TODO: on the long term, this method should become private, but it will be difficult.
     // Especially, how do we deal with InputMethodService.onDisplayCompletions?
     public void setSuggestedWords(final SuggestedWords suggestedWords) {
-        if (!suggestedWords.isEmpty()) {
-            final SuggestedWordInfo suggestedWordInfo;
-            if (suggestedWords.mWillAutoCorrect) {
-                suggestedWordInfo = suggestedWords.getInfo(SuggestedWords.INDEX_OF_AUTO_CORRECTION);
-            } else {
-                // We can't use suggestedWords.getWord(SuggestedWords.INDEX_OF_TYPED_WORD)
-                // because it may differ from mWordComposer.mTypedWord.
-                suggestedWordInfo = suggestedWords.mTypedWordInfo;
-            }
-            mWordComposer.setAutoCorrection(suggestedWordInfo);
+        if (! suggestedWords.isEmpty() && suggestedWords.mWillAutoCorrect) {
+            mWordComposer.setAutoCorrection(suggestedWords.getInfo(SuggestedWords.INDEX_OF_AUTO_CORRECTION));
         }
         mSuggestedWords = suggestedWords;
         final boolean newAutoCorrectionIndicator = suggestedWords.mWillAutoCorrect;


### PR DESCRIPTION
In shift state, suggestions are capitalized, but their scores are based on their non-capitalized versions. Using these capitalized suggestions for autocorrect is thus problematic.

In shift state, the typed word is also capitalized, and since the code I removed here from `InputLogic` seems to treat the typed word as a "fallback autocorrect", that introduced a similar problem.

Fixes #2162.
