### PR TITLE
Dont trim the selection when recapitalizing

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
@@ -47,7 +47,7 @@ import helium314.keyboard.latin.utils.CapsModeUtils;
 import helium314.keyboard.latin.utils.KtxKt;
 import helium314.keyboard.latin.utils.LanguageOnSpacebarUtils;
 import helium314.keyboard.latin.utils.Log;
-import helium314.keyboard.latin.utils.RecapitalizeStatus;
+import helium314.keyboard.latin.utils.RecapitalizeMode;
 import helium314.keyboard.latin.utils.ResourceUtils;
 import helium314.keyboard.latin.utils.ScriptUtils;
 import helium314.keyboard.latin.utils.SubtypeUtilsAdditional;
@@ -456,7 +456,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         if (DEBUG_ACTION) {
             Log.d(TAG, "requestUpdatingShiftState: "
                     + " autoCapsFlags=" + CapsModeUtils.flagsToString(autoCapsFlags)
-                    + " recapitalizeMode=" + RecapitalizeStatus.modeToString(recapitalizeMode));
+                    + " recapitalizeMode=" + RecapitalizeMode.toString(recapitalizeMode));
         }
         mState.onUpdateShiftState(autoCapsFlags, recapitalizeMode);
     }

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
@@ -27,6 +27,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import helium314.keyboard.event.Event;
 import helium314.keyboard.keyboard.KeyboardLayoutSet.KeyboardLayoutSetException;
@@ -139,7 +140,8 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
     }
 
     public void loadKeyboard(final EditorInfo editorInfo, final SettingsValues settingsValues,
-            final int currentAutoCapsState, final int currentRecapitalizeState, KeyboardLayoutSet.InternalAction internalAction) {
+            final int currentAutoCapsState, @Nullable final RecapitalizeMode currentRecapitalizeState,
+            KeyboardLayoutSet.InternalAction internalAction) {
         final KeyboardLayoutSet.Builder builder = new KeyboardLayoutSet.Builder(
                 mThemeContext, editorInfo);
         final int keyboardWidth = ResourceUtils.getKeyboardWidth(mThemeContext, settingsValues);
@@ -223,22 +225,22 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
     // TODO: Remove this method. Come up with a more comprehensive way to reset the keyboard layout
     // when a keyboard layout set doesn't get reloaded in LatinIME.onStartInputViewInternal().
     public void resetKeyboardStateToAlphabet(final int currentAutoCapsState,
-            final int currentRecapitalizeState) {
+            @Nullable final RecapitalizeMode currentRecapitalizeState) {
         mState.onResetKeyboardStateToAlphabet(currentAutoCapsState, currentRecapitalizeState);
     }
 
     public void onPressKey(final int code, final boolean isSinglePointer,
-            final int currentAutoCapsState, final int currentRecapitalizeState) {
+            final int currentAutoCapsState, @Nullable final RecapitalizeMode currentRecapitalizeState) {
         mState.onPressKey(code, isSinglePointer, currentAutoCapsState, currentRecapitalizeState);
     }
 
     public void onReleaseKey(final int code, final boolean withSliding,
-            final int currentAutoCapsState, final int currentRecapitalizeState) {
+            final int currentAutoCapsState, @Nullable final RecapitalizeMode currentRecapitalizeState) {
         mState.onReleaseKey(code, withSliding, currentAutoCapsState, currentRecapitalizeState);
     }
 
     public void onFinishSlidingInput(final int currentAutoCapsState,
-            final int currentRecapitalizeState) {
+            @Nullable final RecapitalizeMode currentRecapitalizeState) {
         mState.onFinishSlidingInput(currentAutoCapsState, currentRecapitalizeState);
     }
 
@@ -384,8 +386,8 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
     }
 
     @Override
-    public void toggleNumpad(final boolean withSliding, final int autoCapsFlags, final int recapitalizeMode,
-            final boolean forceReturnToAlpha) {
+    public void toggleNumpad(final boolean withSliding, final int autoCapsFlags,
+            @Nullable final RecapitalizeMode recapitalizeMode, final boolean forceReturnToAlpha) {
         if (DEBUG_ACTION) {
             Log.d(TAG, "toggleNumpad");
         }
@@ -452,11 +454,11 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
 
     // Future method for requesting an updating to the shift state.
     @Override
-    public void requestUpdatingShiftState(final int autoCapsFlags, final int recapitalizeMode) {
+    public void requestUpdatingShiftState(final int autoCapsFlags, @Nullable final RecapitalizeMode recapitalizeMode) {
         if (DEBUG_ACTION) {
             Log.d(TAG, "requestUpdatingShiftState: "
                     + " autoCapsFlags=" + CapsModeUtils.flagsToString(autoCapsFlags)
-                    + " recapitalizeMode=" + RecapitalizeMode.toString(recapitalizeMode));
+                    + " recapitalizeMode=" + recapitalizeMode);
         }
         mState.onUpdateShiftState(autoCapsFlags, recapitalizeMode);
     }
@@ -598,7 +600,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
      * Updates state machine to figure out when to automatically switch back to the previous mode.
      */
     public void onEvent(final Event event, final int currentAutoCapsState,
-            final int currentRecapitalizeState) {
+            @Nullable final RecapitalizeMode currentRecapitalizeState) {
         mState.onEvent(event, currentAutoCapsState, currentRecapitalizeState);
     }
 

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/KeyboardState.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/KeyboardState.kt
@@ -473,11 +473,11 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
 
     private fun updateShiftStateForRecapitalize(recapitalizeMode: RecapitalizeMode?) {
         val shiftMode = when (recapitalizeMode) {
+            null                                 -> UNSHIFT
             RecapitalizeMode.ORIGINAL_MIXED_CASE -> UNSHIFT
             RecapitalizeMode.ALL_LOWER           -> UNSHIFT
             RecapitalizeMode.FIRST_WORD_UPPER    -> AUTOMATIC_SHIFT
             RecapitalizeMode.ALL_UPPER           -> SHIFT_LOCK_SHIFTED
-            else                                 -> UNSHIFT
         }
         setShifted(shiftMode)
     }

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/KeyboardState.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/KeyboardState.kt
@@ -36,12 +36,12 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
         fun setEmojiKeyboard()
         fun setClipboardKeyboard()
         fun setNumpadKeyboard()
-        fun toggleNumpad(withSliding: Boolean, autoCapsFlags: Int, recapitalizeMode: Int, forceReturnToAlpha: Boolean)
+        fun toggleNumpad(withSliding: Boolean, autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?, forceReturnToAlpha: Boolean)
         fun setSymbolsKeyboard()
         fun setSymbolsShiftedKeyboard()
 
         /** Request to call back [KeyboardState.onUpdateShiftState]. */
-        fun requestUpdatingShiftState(autoCapsFlags: Int, recapitalizeMode: Int)
+        fun requestUpdatingShiftState(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?)
 
         fun startDoubleTapShiftKeyTimer()
         val isInDoubleTapShiftKeyTimeout: Boolean
@@ -67,7 +67,7 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
     private var isSymbolShifted = false
     private var prevMainKeyboardWasShiftLocked = false
     private var prevSymbolsKeyboardWasShifted = false
-    private var recapitalizeMode = RecapitalizeMode.NULL
+    private var recapitalizeMode: RecapitalizeMode? = null
 
     // For handling double tap.
     private var isInAlphabetUnshiftedFromShifted = false
@@ -91,7 +91,7 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
         }
     }
 
-    fun onLoadKeyboard(autoCapsFlags: Int, recapitalizeMode: Int, onHandedModeEnabled: Boolean) {
+    fun onLoadKeyboard(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?, onHandedModeEnabled: Boolean) {
         if (DEBUG_EVENT) {
             Log.d(TAG, "onLoadKeyboard: " + stateToString(autoCapsFlags, recapitalizeMode))
         }
@@ -130,7 +130,7 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
         }
     }
 
-    private fun onRestoreKeyboardState(autoCapsFlags: Int, recapitalizeMode: Int) {
+    private fun onRestoreKeyboardState(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
         if (DEBUG_EVENT) {
             Log.d(TAG, "onRestoreKeyboardState: saved=$savedKeyboardState ${stateToString(autoCapsFlags, recapitalizeMode)}")
         }
@@ -198,7 +198,7 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
         alphabetShiftState.setShiftLocked(shiftLocked)
     }
 
-    private fun toggleAlphabetAndSymbols(autoCapsFlags: Int, recapitalizeMode: Int) {
+    private fun toggleAlphabetAndSymbols(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
         if (DebugFlags.DEBUG_ENABLED) {
             Log.d(TAG, "toggleAlphabetAndSymbols: ${stateToString(autoCapsFlags, recapitalizeMode)}")
         }
@@ -216,7 +216,7 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
 
     // TODO: Remove this method. Come up with a more comprehensive way to reset the keyboard layout
     //  when a keyboard layout set doesn't get reloaded in LatinIME.onStartInputViewInternal().
-    private fun resetKeyboardStateToAlphabet(autoCapsFlags: Int, recapitalizeMode: Int) {
+    private fun resetKeyboardStateToAlphabet(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
         if (DebugFlags.DEBUG_ENABLED) {
             Log.d(TAG, "resetKeyboardStateToAlphabet: ${stateToString(autoCapsFlags, recapitalizeMode)}")
         }
@@ -238,7 +238,7 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
         }
     }
 
-    private fun setAlphabetKeyboard(autoCapsFlags: Int, recapitalizeMode: Int) {
+    private fun setAlphabetKeyboard(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
         if (DebugFlags.DEBUG_ENABLED) {
             Log.d(TAG, "setAlphabetKeyboard: ${stateToString(autoCapsFlags, recapitalizeMode)}")
         }
@@ -246,7 +246,7 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
         mSwitchActions.setAlphabetKeyboard()
         mode = MODE_ALPHABET
         isSymbolShifted = false
-        this.recapitalizeMode = RecapitalizeMode.NULL
+        this.recapitalizeMode = null
         switchState = SWITCH_STATE_ALPHA
         mSwitchActions.requestUpdatingShiftState(autoCapsFlags, recapitalizeMode)
     }
@@ -258,7 +258,7 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
         mSwitchActions.setSymbolsKeyboard()
         mode = MODE_SYMBOLS
         isSymbolShifted = false
-        recapitalizeMode = RecapitalizeMode.NULL
+        recapitalizeMode = null
         // Reset alphabet shift state.
         alphabetShiftState.setShiftLocked(false)
         switchState = SWITCH_STATE_SYMBOL_BEGIN
@@ -271,7 +271,7 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
         mSwitchActions.setSymbolsShiftedKeyboard()
         mode = MODE_SYMBOLS
         isSymbolShifted = true
-        recapitalizeMode = RecapitalizeMode.NULL
+        recapitalizeMode = null
         // Reset alphabet shift state.
         alphabetShiftState.setShiftLocked(false)
         switchState = SWITCH_STATE_SYMBOL_BEGIN
@@ -282,7 +282,7 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
             Log.d(TAG, "setEmojiKeyboard")
         }
         mode = MODE_EMOJI
-        recapitalizeMode = RecapitalizeMode.NULL
+        recapitalizeMode = null
         // Remember caps lock mode and reset alphabet shift state.
         prevMainKeyboardWasShiftLocked = alphabetShiftState.isShiftLocked
         alphabetShiftState.setShiftLocked(false)
@@ -294,7 +294,7 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
             Log.d(TAG, "setClipboardKeyboard")
         }
         mode = MODE_CLIPBOARD
-        recapitalizeMode = RecapitalizeMode.NULL
+        recapitalizeMode = null
         // Remember caps lock mode and reset alphabet shift state.
         prevMainKeyboardWasShiftLocked = alphabetShiftState.isShiftLocked
         alphabetShiftState.setShiftLocked(false)
@@ -318,7 +318,7 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
             modeBeforeNumpad = if (forceReturnToAlpha) MODE_ALPHABET else mode
         }
         mode = MODE_NUMPAD
-        recapitalizeMode = RecapitalizeMode.NULL
+        recapitalizeMode = null
         mSwitchActions.setNumpadKeyboard()
         switchState = if (withSliding) SWITCH_STATE_MOMENTARY_TO_NUMPAD else SWITCH_STATE_NUMPAD_BEGIN
     }
@@ -326,7 +326,7 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
     fun toggleNumpad(
         withSliding: Boolean,
         autoCapsFlags: Int,
-        recapitalizeMode: Int,
+        recapitalizeMode: RecapitalizeMode?,
         forceReturnToAlpha: Boolean,
         rememberState: Boolean
     ) {
@@ -368,7 +368,7 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
         mSwitchActions.switchOneHandedMode()
     }
 
-    fun onPressKey(code: Int, isSinglePointer: Boolean, autoCapsFlags: Int, recapitalizeMode: Int) {
+    fun onPressKey(code: Int, isSinglePointer: Boolean, autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
         if (DEBUG_EVENT) {
             Log.d(TAG, ("onPressKey: code=${Constants.printableCode(code)} single=$isSinglePointer ${stateToString(autoCapsFlags, recapitalizeMode)}"))
         }
@@ -404,7 +404,7 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
         }
     }
 
-    fun onReleaseKey(code: Int, withSliding: Boolean, autoCapsFlags: Int, recapitalizeMode: Int) {
+    fun onReleaseKey(code: Int, withSliding: Boolean, autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
         if (DEBUG_EVENT) {
             Log.d(TAG, "onReleaseKey: code=${Constants.printableCode(code)} sliding=$withSliding ${stateToString(autoCapsFlags, recapitalizeMode)}")
         }
@@ -422,13 +422,13 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
         }
     }
 
-    private fun onPressAlphaSymbol(autoCapsFlags: Int, recapitalizeMode: Int) {
+    private fun onPressAlphaSymbol(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
         toggleAlphabetAndSymbols(autoCapsFlags, recapitalizeMode)
         symbolKeyState.onPress()
         switchState = SWITCH_STATE_MOMENTARY_ALPHA_AND_SYMBOL
     }
 
-    private fun onReleaseAlphaSymbol(withSliding: Boolean, autoCapsFlags: Int, recapitalizeMode: Int) {
+    private fun onReleaseAlphaSymbol(withSliding: Boolean, autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
         if (symbolKeyState.isChording) {
             // Switch back to the previous keyboard mode if the user chords the mode change key and
             // another key, then releases the mode change key.
@@ -442,19 +442,19 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
         symbolKeyState.onRelease()
     }
 
-    private fun onReleaseSymbol(withSliding: Boolean, autoCapsFlags: Int, recapitalizeMode: Int) {
+    private fun onReleaseSymbol(withSliding: Boolean, autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
         val oldMode = mode
         setSymbolsKeyboard()
         if (withSliding && oldMode == MODE_NUMPAD) switchState = SWITCH_STATE_MOMENTARY_FROM_NUMPAD
     }
 
-    private fun onReleaseAlpha(withSliding: Boolean, autoCapsFlags: Int, recapitalizeMode: Int) {
+    private fun onReleaseAlpha(withSliding: Boolean, autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
         val oldMode = mode
         setAlphabetKeyboard(autoCapsFlags, recapitalizeMode)
         if (withSliding && oldMode == MODE_NUMPAD) switchState = SWITCH_STATE_MOMENTARY_FROM_NUMPAD
     }
 
-    fun onUpdateShiftState(autoCapsFlags: Int, recapitalizeMode: Int) {
+    fun onUpdateShiftState(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
         if (DEBUG_EVENT) {
             Log.d(TAG, "onUpdateShiftState: " + stateToString(autoCapsFlags, recapitalizeMode))
         }
@@ -464,14 +464,14 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
 
     // TODO: Remove this method. Come up with a more comprehensive way to reset the keyboard layout
     //  when a keyboard layout set doesn't get reloaded in LatinIME.onStartInputViewInternal().
-    fun onResetKeyboardStateToAlphabet(autoCapsFlags: Int, recapitalizeMode: Int) {
+    fun onResetKeyboardStateToAlphabet(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
         if (DEBUG_EVENT) {
             Log.d(TAG, "onResetKeyboardStateToAlphabet: ${stateToString(autoCapsFlags, recapitalizeMode)}")
         }
         resetKeyboardStateToAlphabet(autoCapsFlags, recapitalizeMode)
     }
 
-    private fun updateShiftStateForRecapitalize(recapitalizeMode: Int) {
+    private fun updateShiftStateForRecapitalize(recapitalizeMode: RecapitalizeMode?) {
         val shiftMode = when (recapitalizeMode) {
             RecapitalizeMode.ORIGINAL_MIXED_CASE -> UNSHIFT
             RecapitalizeMode.ALL_LOWER           -> UNSHIFT
@@ -482,9 +482,9 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
         setShifted(shiftMode)
     }
 
-    private fun updateAlphabetShiftState(autoCapsFlags: Int, recapitalizeMode: Int) {
+    private fun updateAlphabetShiftState(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
         if (mode != MODE_ALPHABET) return
-        if (recapitalizeMode != RecapitalizeMode.NULL) {
+        if (recapitalizeMode != null) {
             // We are recapitalizing. Match the keyboard to the current recapitalize state.
             updateShiftStateForRecapitalize(recapitalizeMode)
         } else if (!shiftKeyState.isReleasing) {
@@ -502,7 +502,7 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
 
     private fun onPressShift() {
         // If we are recapitalizing, we don't do any of the normal processing, including importantly the double tap timer.
-        if (recapitalizeMode != RecapitalizeMode.NULL) {
+        if (recapitalizeMode != null) {
             return
         }
         if (mode != MODE_ALPHABET) {
@@ -543,8 +543,8 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
         }
     }
 
-    private fun onReleaseShift(withSliding: Boolean, autoCapsFlags: Int, recapitalizeMode: Int) {
-        if (this.recapitalizeMode != RecapitalizeMode.NULL) {
+    private fun onReleaseShift(withSliding: Boolean, autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
+        if (this.recapitalizeMode != null) {
             // We are recapitalizing. We should match the keyboard state to the recapitalize state in priority.
             updateShiftStateForRecapitalize(this.recapitalizeMode)
         } else if (mode != MODE_ALPHABET) {
@@ -588,7 +588,7 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
         shiftKeyState.onRelease()
     }
 
-    fun onFinishSlidingInput(autoCapsFlags: Int, recapitalizeMode: Int) {
+    fun onFinishSlidingInput(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
         if (DEBUG_EVENT) {
             Log.d(TAG, "onFinishSlidingInput: " + stateToString(autoCapsFlags, recapitalizeMode))
         }
@@ -603,7 +603,7 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
         }
     }
 
-    fun onEvent(event: Event, autoCapsFlags: Int, recapitalizeMode: Int) {
+    fun onEvent(event: Event, autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
         val code = if (event.isFunctionalKeyEvent) event.keyCode else event.codePoint
         if (DEBUG_EVENT) {
             Log.d(TAG, "onEvent: code=${Constants.printableCode(code)} ${stateToString(autoCapsFlags, recapitalizeMode)}")
@@ -670,8 +670,8 @@ class KeyboardState(private val mSwitchActions: SwitchActions) {
         return "[keyboard=$keyboard shift=$shiftKeyState symbol=$symbolKeyState switch=${switchStateToString(switchState)}]"
     }
 
-    private fun stateToString(autoCapsFlags: Int, recapitalizeMode: Int) =
-        "$this autoCapsFlags=${CapsModeUtils.flagsToString(autoCapsFlags)} recapitalizeMode=${RecapitalizeMode.toString(recapitalizeMode)}"
+    private fun stateToString(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) =
+        "$this autoCapsFlags=${CapsModeUtils.flagsToString(autoCapsFlags)} recapitalizeMode=$recapitalizeMode"
 
     companion object {
         private val TAG = KeyboardState::class.java.simpleName

--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -74,6 +74,7 @@ import helium314.keyboard.latin.utils.JniUtils;
 import helium314.keyboard.latin.utils.KtxKt;
 import helium314.keyboard.latin.utils.LeakGuardHandlerWrapper;
 import helium314.keyboard.latin.utils.Log;
+import helium314.keyboard.latin.utils.RecapitalizeMode;
 import helium314.keyboard.latin.utils.StatsUtils;
 import helium314.keyboard.latin.utils.StatsUtilsManager;
 import helium314.keyboard.latin.utils.SubtypeLocaleUtils;
@@ -1288,7 +1289,8 @@ public class LatinIME extends InputMethodService implements
         return mInputLogic.getCurrentAutoCapsState(mSettings.getCurrent());
     }
 
-    public int getCurrentRecapitalizeState() {
+    @Nullable
+    public RecapitalizeMode getCurrentRecapitalizeState() {
         return mInputLogic.getCurrentRecapitalizeState();
     }
 

--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -57,9 +57,11 @@ import helium314.keyboard.latin.utils.DictionaryInfoUtils;
 import helium314.keyboard.latin.utils.InputTypeUtils;
 import helium314.keyboard.latin.utils.IntentUtils;
 import helium314.keyboard.latin.utils.Log;
+import helium314.keyboard.latin.utils.RecapitalizeMode;
 import helium314.keyboard.latin.utils.RecapitalizeStatus;
 import helium314.keyboard.latin.utils.ScriptUtils;
 import helium314.keyboard.latin.utils.StatsUtils;
+import helium314.keyboard.latin.utils.TextPlacement;
 import helium314.keyboard.latin.utils.TextRange;
 import helium314.keyboard.latin.utils.TimestampKt;
 
@@ -1632,17 +1634,16 @@ public final class InputLogic {
             final CharSequence selectedText =
                     mConnection.getSelectedText(0 /* flags, 0 for no styles */);
             if (TextUtils.isEmpty(selectedText)) return; // Race condition with the input connection
-            mRecapitalizeStatus.start(selectionStart, selectionEnd, selectedText.toString(),
-                    settingsValues.mLocale,
+            mRecapitalizeStatus.start(selectedText.toString(), selectionStart, settingsValues.mLocale,
                     settingsValues.mSpacingAndPunctuations.mSortedWordSeparators);
         }
         mConnection.finishComposingText();
         mRecapitalizeStatus.rotate();
         mConnection.setSelection(selectionEnd, selectionEnd);
         mConnection.deleteTextBeforeCursor(numCharsSelected);
-        mConnection.commitText(mRecapitalizeStatus.getRecapitalizedString(), 0);
-        mConnection.setSelection(mRecapitalizeStatus.getNewCursorStart(),
-                mRecapitalizeStatus.getNewCursorEnd());
+        final TextPlacement replacement = mRecapitalizeStatus.textReplacement();
+        mConnection.commitText(replacement.text, 0);
+        mConnection.setSelection(replacement.selectionStart, replacement.selectionEnd());
     }
 
     private void performAdditionToUserHistoryDictionary(final SettingsValues settingsValues,
@@ -2008,7 +2009,7 @@ public final class InputLogic {
                 || !mRecapitalizeStatus.isSetAt(mConnection.getExpectedSelectionStart(),
                         mConnection.getExpectedSelectionEnd())) {
             // Not recapitalizing at the moment
-            return RecapitalizeStatus.NOT_A_RECAPITALIZE_MODE;
+            return RecapitalizeMode.NULL;
         }
         return mRecapitalizeStatus.getCurrentMode();
     }

--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -1618,7 +1618,7 @@ public final class InputLogic {
      * @param settingsValues The current settings values.
      */
     private void performRecapitalization(final SettingsValues settingsValues) {
-        if (!mConnection.hasSelection() || !mRecapitalizeStatus.mIsEnabled()) {
+        if (!mConnection.hasSelection() || !mRecapitalizeStatus.isEnabled()) {
             return; // No selection or recapitalize is disabled for now
         }
         final int selectionStart = mConnection.getExpectedSelectionStart();

--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -1635,8 +1635,6 @@ public final class InputLogic {
             mRecapitalizeStatus.start(selectionStart, selectionEnd, selectedText.toString(),
                     settingsValues.mLocale,
                     settingsValues.mSpacingAndPunctuations.mSortedWordSeparators);
-            // We trim leading and trailing whitespace.
-            mRecapitalizeStatus.trim();
         }
         mConnection.finishComposingText();
         mRecapitalizeStatus.rotate();

--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -22,6 +22,7 @@ import android.view.inputmethod.CorrectionInfo;
 import android.view.inputmethod.EditorInfo;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import helium314.keyboard.event.Event;
 import helium314.keyboard.event.InputTransaction;
@@ -2004,12 +2005,13 @@ public final class InputLogic {
                 SpaceState.PHANTOM == mSpaceState);
     }
 
-    public int getCurrentRecapitalizeState() {
+    @Nullable
+    public RecapitalizeMode getCurrentRecapitalizeState() {
         if (!mRecapitalizeStatus.isStarted()
                 || !mRecapitalizeStatus.isSetAt(mConnection.getExpectedSelectionStart(),
                         mConnection.getExpectedSelectionEnd())) {
             // Not recapitalizing at the moment
-            return RecapitalizeMode.NULL;
+            return null;
         }
         return mRecapitalizeStatus.getCurrentMode();
     }

--- a/app/src/main/java/helium314/keyboard/latin/utils/RecapitalizeMode.java
+++ b/app/src/main/java/helium314/keyboard/latin/utils/RecapitalizeMode.java
@@ -1,0 +1,61 @@
+package helium314.keyboard.latin.utils;
+
+import java.util.Locale;
+
+import helium314.keyboard.latin.common.StringUtils;
+
+public enum RecapitalizeMode {
+    ;
+    public static final int NULL = -1;
+    public static final int ORIGINAL_MIXED_CASE = 0;
+    public static final int ALL_LOWER = 1;
+    public static final int FIRST_WORD_UPPER = 2;
+    public static final int ALL_UPPER = 3;
+    // When adding a new mode, don't forget to update the ROTATION_SIZE constant.
+    private static final int ROTATION_SIZE = 4;
+
+    public static int of(final String string, final int[] sortedSeparators) {
+        if (StringUtils.isIdenticalAfterUpcase(string)) {
+            return ALL_UPPER;
+        } else if (StringUtils.isIdenticalAfterDowncase(string)) {
+            return ALL_LOWER;
+        } else if (StringUtils.isIdenticalAfterCapitalizeEachWord(string, sortedSeparators)) {
+            return FIRST_WORD_UPPER;
+        } else {
+            return ORIGINAL_MIXED_CASE;
+        }
+    }
+
+    public static int count() {
+        return ROTATION_SIZE;
+    }
+
+    public static int rotate(int recapitalizeMode, boolean skipOriginalMixedCaseMode) {
+        ++recapitalizeMode;
+        if (recapitalizeMode == ROTATION_SIZE) {
+            recapitalizeMode = skipOriginalMixedCaseMode ? 1 : 0;
+        }
+        return recapitalizeMode;
+    }
+
+    public static String apply(int recapitalizeMode, String text, int[] sortedSeparators, Locale locale) {
+        return switch (recapitalizeMode) {
+            case RecapitalizeMode.ORIGINAL_MIXED_CASE -> text;
+            case RecapitalizeMode.ALL_LOWER -> text.toLowerCase(locale);
+            case RecapitalizeMode.FIRST_WORD_UPPER -> StringUtils.capitalizeEachWord(text, sortedSeparators, locale);
+            case RecapitalizeMode.ALL_UPPER -> text.toUpperCase(locale);
+            default -> throw new IllegalArgumentException();
+        };
+    }
+
+    public static String toString(int recapitalizeMode) {
+        return switch (recapitalizeMode) {
+            case NULL -> "undefined";
+            case ORIGINAL_MIXED_CASE -> "mixedCase";
+            case ALL_LOWER -> "allLower";
+            case FIRST_WORD_UPPER -> "firstWordUpper";
+            case ALL_UPPER -> "allUpper";
+            default -> throw new IllegalArgumentException();
+        };
+    }
+}

--- a/app/src/main/java/helium314/keyboard/latin/utils/RecapitalizeMode.java
+++ b/app/src/main/java/helium314/keyboard/latin/utils/RecapitalizeMode.java
@@ -5,16 +5,34 @@ import java.util.Locale;
 import helium314.keyboard.latin.common.StringUtils;
 
 public enum RecapitalizeMode {
-    ;
-    public static final int NULL = -1;
-    public static final int ORIGINAL_MIXED_CASE = 0;
-    public static final int ALL_LOWER = 1;
-    public static final int FIRST_WORD_UPPER = 2;
-    public static final int ALL_UPPER = 3;
-    // When adding a new mode, don't forget to update the ROTATION_SIZE constant.
-    private static final int ROTATION_SIZE = 4;
+    ORIGINAL_MIXED_CASE {
+        @Override
+        public String apply(String text, int[] sortedSeparators, Locale locale) {
+            return text;
+        }
+    },
+    ALL_LOWER {
+        @Override
+        public String apply(String text, int[] sortedSeparators, Locale locale) {
+            return text.toLowerCase(locale);
+        }
+    },
+    FIRST_WORD_UPPER {
+        @Override
+        public String apply(String text, int[] sortedSeparators, Locale locale) {
+            return StringUtils.capitalizeEachWord(text, sortedSeparators, locale);
+        }
+    },
+    ALL_UPPER {
+        @Override
+        public String apply(String text, int[] sortedSeparators, Locale locale) {
+            return text.toUpperCase(locale);
+        }
+    };
 
-    public static int of(final String string, final int[] sortedSeparators) {
+    private static RecapitalizeMode[] sCarousel = values();
+
+    public static RecapitalizeMode of(final String string, final int[] sortedSeparators) {
         if (StringUtils.isIdenticalAfterUpcase(string)) {
             return ALL_UPPER;
         } else if (StringUtils.isIdenticalAfterDowncase(string)) {
@@ -27,35 +45,16 @@ public enum RecapitalizeMode {
     }
 
     public static int count() {
-        return ROTATION_SIZE;
+        return sCarousel.length;
     }
 
-    public static int rotate(int recapitalizeMode, boolean skipOriginalMixedCaseMode) {
-        ++recapitalizeMode;
-        if (recapitalizeMode == ROTATION_SIZE) {
-            recapitalizeMode = skipOriginalMixedCaseMode ? 1 : 0;
+    public final RecapitalizeMode rotate(boolean skipOriginalMixedCaseMode) {
+        int position = ordinal() + 1;
+        if (position == sCarousel.length) {
+            position = skipOriginalMixedCaseMode ? 1 : 0;
         }
-        return recapitalizeMode;
+        return sCarousel[position];
     }
 
-    public static String apply(int recapitalizeMode, String text, int[] sortedSeparators, Locale locale) {
-        return switch (recapitalizeMode) {
-            case RecapitalizeMode.ORIGINAL_MIXED_CASE -> text;
-            case RecapitalizeMode.ALL_LOWER -> text.toLowerCase(locale);
-            case RecapitalizeMode.FIRST_WORD_UPPER -> StringUtils.capitalizeEachWord(text, sortedSeparators, locale);
-            case RecapitalizeMode.ALL_UPPER -> text.toUpperCase(locale);
-            default -> throw new IllegalArgumentException();
-        };
-    }
-
-    public static String toString(int recapitalizeMode) {
-        return switch (recapitalizeMode) {
-            case NULL -> "undefined";
-            case ORIGINAL_MIXED_CASE -> "mixedCase";
-            case ALL_LOWER -> "allLower";
-            case FIRST_WORD_UPPER -> "firstWordUpper";
-            case ALL_UPPER -> "allUpper";
-            default -> throw new IllegalArgumentException();
-        };
-    }
+    public abstract String apply(String text, int[] sortedSeparators, Locale locale);
 }

--- a/app/src/main/java/helium314/keyboard/latin/utils/RecapitalizeStatus.java
+++ b/app/src/main/java/helium314/keyboard/latin/utils/RecapitalizeStatus.java
@@ -52,11 +52,8 @@ public class RecapitalizeStatus {
         };
     }
 
-    /**
-     * We store the location of the cursor and the string that was there before the recapitalize
-     * action was done, and the location of the cursor and the string that was there after.
-     */
-    private int mCursorStartBefore;
+    // We store the location of the cursor and the string that was there before the recapitalize
+    // action was done, and the location of the cursor and the string that was there after.
     private String mStringBefore;
     private int mCursorStartAfter;
     private int mCursorEndAfter;
@@ -81,7 +78,6 @@ public class RecapitalizeStatus {
         if (!mIsEnabled) {
             return;
         }
-        mCursorStartBefore = cursorStart;
         mStringBefore = string;
         mCursorStartAfter = cursorStart;
         mCursorEndAfter = cursorEnd;
@@ -152,34 +148,6 @@ public class RecapitalizeStatus {
             }
         } while (mStringAfter.equals(oldResult) && count < ROTATION_STYLE.length + 1);
         mCursorEndAfter = mCursorStartAfter + mStringAfter.length();
-    }
-
-    /**
-     * Remove leading/trailing whitespace from the considered string.
-     */
-    public void trim() {
-        final int len = mStringBefore.length();
-        int nonWhitespaceStart = 0;
-        for (; nonWhitespaceStart < len;
-                nonWhitespaceStart = mStringBefore.offsetByCodePoints(nonWhitespaceStart, 1)) {
-            final int codePoint = mStringBefore.codePointAt(nonWhitespaceStart);
-            if (!Character.isWhitespace(codePoint)) break;
-        }
-        int nonWhitespaceEnd = len;
-        for (; nonWhitespaceEnd > 0;
-                nonWhitespaceEnd = mStringBefore.offsetByCodePoints(nonWhitespaceEnd, -1)) {
-            final int codePoint = mStringBefore.codePointBefore(nonWhitespaceEnd);
-            if (!Character.isWhitespace(codePoint)) break;
-        }
-        // If nonWhitespaceStart >= nonWhitespaceEnd, that means the selection contained only
-        // whitespace, so we leave it as is.
-        if ((0 != nonWhitespaceStart || len != nonWhitespaceEnd)
-                && nonWhitespaceStart < nonWhitespaceEnd) {
-            mCursorEndAfter = mCursorStartBefore + nonWhitespaceEnd;
-            mCursorStartBefore = mCursorStartAfter = mCursorStartBefore + nonWhitespaceStart;
-            mStringAfter = mStringBefore =
-                    mStringBefore.substring(nonWhitespaceStart, nonWhitespaceEnd);
-        }
     }
 
     public String getRecapitalizedString() {

--- a/app/src/main/java/helium314/keyboard/latin/utils/RecapitalizeStatus.java
+++ b/app/src/main/java/helium314/keyboard/latin/utils/RecapitalizeStatus.java
@@ -58,7 +58,7 @@ public class RecapitalizeStatus {
         mIsEnabled = false;
     }
 
-    public boolean mIsEnabled() {
+    public boolean isEnabled() {
         return mIsEnabled;
     }
 

--- a/app/src/main/java/helium314/keyboard/latin/utils/RecapitalizeStatus.java
+++ b/app/src/main/java/helium314/keyboard/latin/utils/RecapitalizeStatus.java
@@ -16,7 +16,7 @@ public class RecapitalizeStatus {
     // action was done, and the location of the cursor and the string that was there after.
     private String mText;
     private TextPlacement mTextPlacement;
-    private int mCurrentMode;
+    private RecapitalizeMode mCurrentMode;
     private boolean mSkipOriginalMixedCaseMode;
     private Locale mLocale;
     private int[] mSortedSeparators;
@@ -74,8 +74,8 @@ public class RecapitalizeStatus {
         String replacement;
         int i = 0; // Protection against infinite loop.
         do {
-            mCurrentMode = RecapitalizeMode.rotate(mCurrentMode, mSkipOriginalMixedCaseMode);
-            replacement = RecapitalizeMode.apply(mCurrentMode, mText, mSortedSeparators, mLocale);
+            mCurrentMode = mCurrentMode.rotate(mSkipOriginalMixedCaseMode);
+            replacement = mCurrentMode.apply(mText, mSortedSeparators, mLocale);
             ++i;
         } while (replacement.equals(mTextPlacement.text) && i <= modeCount);
         mTextPlacement.text = replacement;
@@ -85,7 +85,7 @@ public class RecapitalizeStatus {
         return mTextPlacement;
     }
 
-    public int getCurrentMode() {
+    public RecapitalizeMode getCurrentMode() {
         return mCurrentMode;
     }
 }

--- a/app/src/main/java/helium314/keyboard/latin/utils/TextPlacement.java
+++ b/app/src/main/java/helium314/keyboard/latin/utils/TextPlacement.java
@@ -1,0 +1,15 @@
+package helium314.keyboard.latin.utils;
+
+public final class TextPlacement {
+    public String text;
+    public final int selectionStart;
+
+    public TextPlacement(String text, int selectionStart) {
+        this.text = text;
+        this.selectionStart = selectionStart;
+    }
+
+    public int selectionEnd() {
+        return selectionStart + text.length();
+    }
+}


### PR DESCRIPTION
Fixes #2224 by deleting the `RecapitalizeStatus.trim()` function. While I was at it, I did some code cleanup in `RecapitalizeStatus` including separating the "recapitalize mode" as an enum.