### PR TITLE
feat(clipboard): add image pasting

### DIFF
--- a/app/src/main/java/helium314/keyboard/compat/EditorInfoCompatUtils.kt
+++ b/app/src/main/java/helium314/keyboard/compat/EditorInfoCompatUtils.kt
@@ -9,6 +9,7 @@ package helium314.keyboard.compat
 import android.os.Build
 import android.text.InputType
 import android.view.inputmethod.EditorInfo
+import androidx.core.view.inputmethod.EditorInfoCompat
 import helium314.keyboard.latin.utils.Log
 import java.util.*
 
@@ -42,6 +43,16 @@ object EditorInfoCompatUtils {
         val sentenceCaps = (editorInfo.inputType and InputType.TYPE_TEXT_FLAG_CAP_SENTENCES) != 0
         val wordCaps = (editorInfo.inputType and InputType.TYPE_TEXT_FLAG_CAP_WORDS) != 0
         Log.d(tag, ("All caps: $allCaps, sentence caps: $sentenceCaps, word caps: $wordCaps"))
+    }
+
+    @JvmStatic
+    fun isMimeTypeSupportedByEditor(editorInfo: EditorInfo?, mimeType: String): Boolean {
+        if (editorInfo == null) return false
+        val supportedMimeTypes = EditorInfoCompat.getContentMimeTypes(editorInfo)
+        return supportedMimeTypes.any { supported ->
+            supported == "*/*" || supported == mimeType
+                    || (supported.endsWith("/*") && mimeType.startsWith(supported.removeSuffix("*")))
+        }
     }
 
     @JvmStatic

--- a/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
+++ b/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
@@ -4,6 +4,7 @@ package helium314.keyboard.latin
 
 import android.content.ClipboardManager
 import android.content.Context
+import android.net.Uri
 import android.text.InputType
 import android.text.TextUtils
 import android.view.LayoutInflater
@@ -99,6 +100,12 @@ class ClipboardHistoryManager(
         val clipData = clipboardManager.primaryClip ?: return ""
         if (clipData.itemCount == 0) return ""
         return clipData.getItemAt(0)?.coerceToText(latinIME) ?: ""
+    }
+
+    fun retrieveClipboardUri(): Uri? {
+        val clipData = clipboardManager.primaryClip ?: return null
+        if (clipData.itemCount == 0) return null
+        return clipData.getItemAt(0)?.uri
     }
 
     private fun isClipSensitive(inputType: Int): Boolean {

--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -9,6 +9,7 @@ package helium314.keyboard.latin;
 import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.content.BroadcastReceiver;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -17,6 +18,7 @@ import android.content.res.Resources;
 import android.graphics.Color;
 import android.inputmethodservice.InputMethodService;
 import android.media.AudioManager;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Debug;
@@ -1387,6 +1389,22 @@ public class LatinIME extends InputMethodService implements
         updateStateAfterInputTransaction(completeInputTransaction);
         mInputLogic.restartSuggestionsOnWordTouchedByCursor(mSettings.getCurrent(), mKeyboardSwitcher.getCurrentKeyboardScript());
         mKeyboardSwitcher.onEvent(event, getCurrentAutoCapsState(), getCurrentRecapitalizeState());
+    }
+
+    public void onUriInput(final Uri uri) {
+        final EditorInfo editorInfo = getCurrentInputEditorInfo();
+        if (editorInfo == null) return;
+
+        final ContentResolver cr = getContentResolver();
+        String mimeType = cr.getType(uri);
+        if (mimeType == null) mimeType = "application/octet-stream";
+
+        if (!EditorInfoCompatUtils.isMimeTypeSupportedByEditor(editorInfo, mimeType)) {
+            mKeyboardSwitcher.showToast(getString(R.string.toast_msg_unsupported_uri), true);
+            return;
+        }
+
+        mInputLogic.mConnection.commitContent(uri, mimeType, editorInfo);
     }
 
     public void onStartBatchInput() {

--- a/app/src/main/java/helium314/keyboard/latin/RichInputConnection.java
+++ b/app/src/main/java/helium314/keyboard/latin/RichInputConnection.java
@@ -10,6 +10,7 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.inputmethodservice.InputMethodService;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.SystemClock;
@@ -24,6 +25,7 @@ import helium314.keyboard.latin.utils.Log;
 import android.view.KeyEvent;
 import android.view.inputmethod.CompletionInfo;
 import android.view.inputmethod.CorrectionInfo;
+import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.ExtractedText;
 import android.view.inputmethod.ExtractedTextRequest;
 import android.view.inputmethod.InputConnection;
@@ -31,6 +33,8 @@ import android.view.inputmethod.InputMethodManager;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.view.inputmethod.InputConnectionCompat;
+import androidx.core.view.inputmethod.InputContentInfoCompat;
 
 import helium314.keyboard.latin.common.Constants;
 import helium314.keyboard.latin.common.StringUtils;
@@ -1175,5 +1179,18 @@ public final class RichInputConnection implements PrivateCommandPerformer {
         final int cursorUpdateMode = (enableMonitor ? InputConnection.CURSOR_UPDATE_MONITOR : 0)
             | (requestImmediateCallback ? InputConnection.CURSOR_UPDATE_IMMEDIATE : 0);
         return mIC.requestCursorUpdates(cursorUpdateMode);
+    }
+
+    public boolean commitContent(@NonNull final Uri uri, @NonNull final String mimeType,
+            @NonNull final EditorInfo editorInfo) {
+        mIC = mParent.getCurrentInputConnection();
+        if (!isConnected()) {
+            return false;
+        }
+        final InputContentInfoCompat contentInfo = new InputContentInfoCompat(uri,
+                new android.content.ClipDescription("clipboard image", new String[]{mimeType}),
+                null);
+        return InputConnectionCompat.commitContent(mIC, editorInfo, contentInfo,
+                InputConnectionCompat.INPUT_CONTENT_GRANT_READ_URI_PERMISSION, null);
     }
 }

--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -651,6 +651,11 @@ public final class InputLogic {
      *
      */
     private void handleClipboardPaste() {
+        final android.net.Uri clipUri = mLatinIME.getClipboardHistoryManager().retrieveClipboardUri();
+        if (clipUri != null) {
+            mLatinIME.onUriInput(clipUri);
+            return;
+        }
         final String clipboardContent = mLatinIME.getClipboardHistoryManager().retrieveClipboardContent().toString();
         if (!clipboardContent.isEmpty()) {
             mLatinIME.onTextInput(clipboardContent);

--- a/app/src/main/res/layout/clipboard_suggestion.xml
+++ b/app/src/main/res/layout/clipboard_suggestion.xml
@@ -7,6 +7,7 @@
     android:paddingEnd="12dp"
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
+    android:clipToOutline="true"
     tools:ignore="RtlSymmetry">
     <TextView
         android:id="@+id/clipboard_suggestion_text"
@@ -22,6 +23,14 @@
         android:ellipsize="end"
         android:textStyle="bold"
         style="?android:attr/textAppearanceSmall" />
+    <ImageView
+        android:id="@+id/clipboard_suggestion_image"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:adjustViewBounds="true"
+        android:scaleType="centerInside"
+        android:paddingHorizontal="12dp"
+        android:visibility="gone" />
     <ImageView
         android:id="@+id/clipboard_suggestion_close"
         android:contentDescription="@string/spoken_clipboard_suggestion"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -903,6 +903,8 @@ New dictionary:
     <string name="auto_hide_toolbar_summary">Hide the toolbar when suggestions become available</string>
     <!-- Toast message shown when content is copied to the clipboard -->
     <string name="toast_msg_clipboard_copy">Content copied</string>
+    <!-- Toast message shown when trying to paste a URI that the editor doesn't support -->
+    <string name="toast_msg_unsupported_uri">This app does not support pasting this content type</string>
     <!-- Title of the setting to customize icons for keyboard and toolbar keys -->
     <string name="customize_icons">Customize icons</string>
     <!-- Confirmation message when resetting all custom icons -->


### PR DESCRIPTION
Adds support for pasting images from the system clipboard via `commitContent`.

- When an app supports image input (e.g. messaging apps), the paste toolbar key now sends clipboard images using `InputConnectionCompat.commitContent`
- The clipboard suggestion strip shows an image thumbnail when an image is on the clipboard, instead of only handling text
- Tapping the thumbnail pastes the image; tapping X dismisses it
- If the target app doesn't support the image MIME type, a toast is shown

Part of #490 (second part will be history)

<img width="1024" height="891" alt="image" src="https://github.com/user-attachments/assets/2538782b-f349-4e1e-b27b-e7d985de3c9a" />
