### PR TITLE
Feat: Add Option to Delete Whole Words When Holding Backspace

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -1640,14 +1640,19 @@ public class LatinIME extends InputMethodService implements
             }
             // TODO: Use event time that the last feedback has been generated instead of relying on
             // a repeat count to thin out feedback.
-            if (repeatCount % PERIOD_FOR_AUDIO_AND_HAPTIC_FEEDBACK_IN_KEY_REPEAT == 0) {
+            // Don't thin out feedback for delete key when deleting whole words.
+            final boolean deleteWholeWords = Settings.getValues() != null && Settings.getValues().mDeleteWholeWords;
+            if (!(code == KeyCode.DELETE && deleteWholeWords)
+                    && repeatCount % PERIOD_FOR_AUDIO_AND_HAPTIC_FEEDBACK_IN_KEY_REPEAT == 0) {
                 return;
             }
         }
         final AudioAndHapticFeedbackManager feedbackManager =
                 AudioAndHapticFeedbackManager.getInstance();
         if (repeatCount == 0) {
-            // TODO: Reconsider how to perform haptic feedback when repeating key.
+            feedbackManager.performHapticFeedback(keyboardView, hapticEvent);
+        } else if (code == KeyCode.DELETE && Settings.getValues() != null && Settings.getValues().mDeleteWholeWords) {
+            // Vibrate on every backspace repeat when deleting whole words
             feedbackManager.performHapticFeedback(keyboardView, hapticEvent);
         }
         feedbackManager.performAudioFeedback(code, hapticEvent);

--- a/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
@@ -64,6 +64,7 @@ object Defaults {
     const val PREF_AUTO_CORRECT_THRESHOLD = 0.185f
     const val PREF_AUTOCORRECT_SHORTCUTS = true
     const val PREF_BACKSPACE_REVERTS_AUTOCORRECT = true
+    const val PREF_DELETE_WHOLE_WORDS = false
     const val PREF_CENTER_SUGGESTION_TEXT_TO_ENTER = false
     const val PREF_SHOW_SUGGESTIONS = true
     const val PREF_ALWAYS_SHOW_SUGGESTIONS = false

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -80,6 +80,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_AUTO_CORRECT_THRESHOLD = "auto_correct_threshold";
     public static final String PREF_AUTOCORRECT_SHORTCUTS = "autocorrect_shortcuts";
     public static final String PREF_BACKSPACE_REVERTS_AUTOCORRECT = "backspace_reverts_autocorrect";
+    public static final String PREF_DELETE_WHOLE_WORDS = "delete_whole_words";
     public static final String PREF_CENTER_SUGGESTION_TEXT_TO_ENTER = "center_suggestion_text_to_enter";
     public static final String PREF_SHOW_SUGGESTIONS = "show_suggestions";
     public static final String PREF_ALWAYS_SHOW_SUGGESTIONS = "always_show_suggestions";

--- a/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
@@ -146,6 +146,7 @@ public class SettingsValues {
     public final boolean mAutoCorrectEnabled;
     public final float mAutoCorrectionThreshold;
     public final boolean mBackspaceRevertsAutocorrect;
+    public final boolean mDeleteWholeWords;
     public final int mScoreLimitForAutocorrect;
     public final boolean mAutoCorrectShortcuts;
     private final boolean mSuggestionsEnabledPerUserSettings;
@@ -213,6 +214,7 @@ public class SettingsValues {
                 : (mAutoCorrectionThreshold < 0.07 ? 800000 : 950000); // aggressive or modest
         mAutoCorrectShortcuts = prefs.getBoolean(Settings.PREF_AUTOCORRECT_SHORTCUTS, Defaults.PREF_AUTOCORRECT_SHORTCUTS);
         mBackspaceRevertsAutocorrect = prefs.getBoolean(Settings.PREF_BACKSPACE_REVERTS_AUTOCORRECT, Defaults.PREF_BACKSPACE_REVERTS_AUTOCORRECT);
+        mDeleteWholeWords = prefs.getBoolean(Settings.PREF_DELETE_WHOLE_WORDS, Defaults.PREF_DELETE_WHOLE_WORDS);
         mBigramPredictionEnabled = prefs.getBoolean(Settings.PREF_BIGRAM_PREDICTIONS, Defaults.PREF_BIGRAM_PREDICTIONS);
         mSuggestPunctuation = prefs.getBoolean(Settings.PREF_SUGGEST_PUNCTUATION, Defaults.PREF_SUGGEST_PUNCTUATION);
         mSuggestClipboardContent = prefs.getBoolean(Settings.PREF_SUGGEST_CLIPBOARD_CONTENT, Defaults.PREF_SUGGEST_CLIPBOARD_CONTENT);

--- a/app/src/main/java/helium314/keyboard/settings/screens/TextCorrectionScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/TextCorrectionScreen.kt
@@ -66,6 +66,7 @@ fun TextCorrectionScreen(
         if (autocorrectEnabled) Settings.PREF_AUTOCORRECT_SHORTCUTS else null,
         if (autocorrectEnabled) Settings.PREF_AUTO_CORRECT_THRESHOLD else null,
         if (autocorrectEnabled) Settings.PREF_BACKSPACE_REVERTS_AUTOCORRECT else null,
+        Settings.PREF_DELETE_WHOLE_WORDS,
         Settings.PREF_AUTO_CAP,
         R.string.settings_category_space,
         Settings.PREF_KEY_USE_DOUBLE_SPACE_PERIOD,
@@ -136,6 +137,11 @@ fun createCorrectionSettings(context: Context) = listOf(
     },
     Setting(context, Settings.PREF_BACKSPACE_REVERTS_AUTOCORRECT, R.string.backspace_reverts_autocorrect) {
         SwitchPreference(it, Defaults.PREF_BACKSPACE_REVERTS_AUTOCORRECT)
+    },
+    Setting(context, Settings.PREF_DELETE_WHOLE_WORDS,
+        R.string.delete_whole_words, R.string.delete_whole_words_summary
+    ) {
+        SwitchPreference(it, Defaults.PREF_DELETE_WHOLE_WORDS)
     },
     Setting(context, Settings.PREF_AUTO_CAP,
         R.string.auto_cap, R.string.auto_cap_summary

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -146,6 +146,8 @@
     <string name="auto_correct_shortcuts_summary">When enabled shortcuts might be expanded by autocorrect</string>
     <!-- Option to undo auto correction with backspace -->
     <string name="backspace_reverts_autocorrect">Backspace reverts autocorrect</string>
+    <string name="delete_whole_words">Hold backspace deletes whole words</string>
+    <string name="delete_whole_words_summary">When holding the backspace key, delete entire words instead of individual characters</string>
     <!-- Option to disable auto correction. -->
     <string name="auto_correction_threshold_mode_off">Off</string> <!-- todo: use it or remove it -->
     <!-- Option to suggest auto correction suggestions modestly. Auto-corrects only to a word which has small edit distance from typed word. -->


### PR DESCRIPTION
Adds a **"Hold backspace deletes whole words"** toggle in Text Correction settings (off by default). When enabled, holding the backspace key deletes entire words instead of individual characters.

**Related:** #1289 — this addresses the hold-backspace behavior discussed in that thread. The swipe-delete behavior requested in the original issue is not changed by this PR.

### Implementation

- Uses `BreakIterator.getWordInstance()` for accurate word boundary detection
- Gradually increasing repeat speed (starts slow, speeds up with continued holding)
- Haptic feedback fires on every word deletion
- Composing words are deleted whole on the first repeat
- All behavior changes are behind the settings toggle — default behavior is unchanged

### Files Changed

- `InputLogic.java` — word deletion logic for both composing and committed text
- `PointerTracker.java` — adjusted repeat timing when deleting words
- `LatinIME.java` — haptic feedback on every backspace repeat when enabled
- `Settings.java` / `Defaults.kt` / `SettingsValues.java` — new preference
- `TextCorrectionScreen.kt` — settings UI
- `strings.xml` — setting label and description