### PR TITLE
Fix popup key labels being randomly changed

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/KeyboardParser.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/KeyboardParser.kt
@@ -270,12 +270,8 @@ class KeyboardParser(private val params: KeyboardParams, private val context: Co
             numberRowCopy.forEachIndexed { index, keyData -> keyData.popup.symbol = baseKeys[0].getOrNull(index)?.label }
             baseKeys[0] = numberRowCopy
         } else if (!params.mId.mNumberRowEnabled && params.mId.isAlphabetKeyboard && !hasBuiltInNumbers()) {
-            if (baseKeys[0].any { it.popup.main != null || !it.popup.relevant.isNullOrEmpty() } // first row of baseKeys has any layout popup key
-                && params.mPopupKeyLabelSources.let {
-                    val layout = it.indexOf(POPUP_KEYS_LAYOUT)
-                    val number = it.indexOf(POPUP_KEYS_NUMBER)
-                    layout != -1 && layout < number // layout before number label
-                }
+            if (baseKeys[0].any { !it.popup.isEmpty() } // first row of baseKeys has any layout popup key
+                && POPUP_KEYS_LAYOUT in params.mPopupKeyLabelSources
             ) {
                 // remove number from labels, to avoid awkward mix of numbers and others caused by layout popup keys
                 params.mPopupKeyLabelSources.remove(POPUP_KEYS_NUMBER)


### PR DESCRIPTION
Fixes #2455

The popup label logic was convoluted with nested conditionals checking if layout appeared before number in the sources. We don't need that. If the first row has popups and layout's in the sources, we remove numbers to avoid mixing them.

Simplified the condition and tested with a few different keyboard configs.