### PR TITLE
fix delete swipe being delayed after letter input

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -932,7 +932,9 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         final int fastTypingTimeout = 2 * sv.mKeyLongpressTimeout / 3;
         // we don't want keyswipes to start immediately if the user is fast-typing,
         // see https://github.com/openboard-team/openboard/issues/411
-        if (SystemClock.elapsedRealtime() < mStartTime + fastTypingTimeout && sTypingTimeRecorder.isInFastTyping(eventTime))
+        // delete swipe is excluded because it already has a distance threshold,
+        // see https://github.com/openboard-team/openboard/pull/566
+        if (code != KeyCode.DELETE && SystemClock.elapsedRealtime() < mStartTime + fastTypingTimeout && sTypingTimeRecorder.isInFastTyping(eventTime))
             return;
         if (code == Constants.CODE_SPACE) {
             int dX = x - mStartX;


### PR DESCRIPTION
The fast-typing timeout guard in onKeySwipe() was suppressing delete swipes for ~200ms after typing a letter, causing them to register as single backspace presses instead. This guard was originally added for space swipes (openboard#411), but delete swipe already has its own distance threshold for preventing accidental activation (openboard#566).

Exclude KeyCode.DELETE from the fast-typing timeout check so delete swipes are handled purely by their distance threshold.

Fixes #2488