### PR TITLE
Clipboard suggestion: mask based on content patterns (OTP/CC/JWT/seed/secret)

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
+++ b/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
@@ -104,7 +104,22 @@ class ClipboardHistoryManager(
 
     private fun isClipSensitive(inputType: Int): Boolean {
         ClipboardManagerCompat.getClipSensitivity(clipboardManager.primaryClip?.description)?.let { return it }
-        return InputTypeUtils.isPasswordInputType(inputType)
+        if (InputTypeUtils.isPasswordInputType(inputType)) return true
+        val content = retrieveClipboardContent()
+        return isContentSensitive(content)
+    }
+
+    private fun isContentSensitive(content: CharSequence): Boolean {
+        if (content.isEmpty()) return false
+        val text = content.toString()
+        if (text.length > 5000) return false
+        if (P_OTP.matcher(text).matches()) return true
+        if (P_CREDIT_CARD.matcher(text).find()) return true
+        if (P_JWT.matcher(text).find()) return true
+        if (P_LONG_HEX.matcher(text).find()) return true
+        if (P_SEED_PHRASE.matcher(text.trim()).matches()) return true
+        if (P_SECRET_KEYWORD.matcher(text).find()) return true
+        return false
     }
 
     fun getClipboardSuggestionView(editorInfo: EditorInfo?, parent: ViewGroup?): View? {
@@ -168,5 +183,14 @@ class ClipboardHistoryManager(
     companion object {
         private var dontShowCurrentSuggestion: Boolean = false
         const val RECENT_TIME_MILLIS = 3 * 60 * 1000L // 3 minutes (for clipboard suggestions)
+
+        private val P_OTP = java.util.regex.Pattern.compile("^\\s*\\d{4,8}\\s*$")
+        private val P_CREDIT_CARD = java.util.regex.Pattern.compile("\\b(?:\\d[ -]*?){13,19}\\b")
+        private val P_JWT = java.util.regex.Pattern.compile("\\beyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\b")
+        private val P_LONG_HEX = java.util.regex.Pattern.compile("\\b[a-fA-F0-9]{32,}\\b")
+        private val P_SEED_PHRASE = java.util.regex.Pattern.compile("(?:[a-z]{3,8}\\s+){11,23}[a-z]{3,8}")
+        private val P_SECRET_KEYWORD = java.util.regex.Pattern.compile(
+            "(?i)\\b(password|passwd|secret|api[_-]?key|access[_-]?token|bearer|private[_-]?key|ssh-rsa|ssh-ed25519|-----BEGIN [A-Z ]+PRIVATE KEY-----)\\b"
+        )
     }
 }


### PR DESCRIPTION
## Summary

`isClipSensitive()` currently only returns `true` when the target input field declares `inputType=textPassword` or the OS-side `ClipDescription` sensitivity flag is set. That leaves OTPs, credit-card numbers, BIP-39 seed phrases, JWTs, and PEM private keys visible in plaintext on the suggestion strip whenever the user is pasting into a normal text field (chat composer, email body, search bar) — which is the most common shoulder-surf risk in practice.

This PR extends `isClipSensitive()` to additionally inspect the clipboard content itself, returning `true` (and therefore masking the visible suggestion to `***...***`) if the content matches any of:

| Pattern | Matches |
|---|---|
| `P_OTP` | Standalone 4–8 digit run (whole-string match) |
| `P_CREDIT_CARD` | 13–19 digit run with optional spaces/dashes |
| `P_JWT` | `eyJ…\.<base64url>\.<base64url>` |
| `P_LONG_HEX` | Hex string ≥ 32 chars (SHA-256, API tokens, hex-encoded keys) |
| `P_SEED_PHRASE` | 12–24 lowercase 3–8 char words space-separated (BIP-39 style) |
| `P_SECRET_KEYWORD` | `password`, `passwd`, `secret`, `api_key`, `access_token`, `bearer`, `private_key`, `ssh-rsa`, `ssh-ed25519`, PEM private key block |

## Behavior

- The masking only affects the **visible suggestion strip text**. The actual paste still uses the real content via `latinIME.onTextInput(content.toString())` — so functionality is unchanged for the user, they just don't see a 6-digit OTP rendered in 18pt next to whoever might be looking over their shoulder.
- 5000-char ceiling on the regex scan to avoid pathological clipboard payloads (e.g., full HTML pages on the clipboard) hitting the regex engine on every keystroke.
- Pattern list is intentionally conservative — false positives just mean "user sees `***` instead of the value for ~3 minutes of clipboard freshness", false negatives mean the value is visible.

## Files touched

- `app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt` (+25 / −1)

## Tested

Built and installed on Android 16 (`HeliBoard_3.9-debug.apk`). Verified manually with sample clipboard contents matching each pattern.

## Notes

No new permissions. No new strings (the existing `*`-repeat path is reused). No settings — this is pure defense-in-depth on an existing privacy-sensitive code path. If you'd prefer this gated behind a setting, happy to add one.