### PR TITLE
add option to delete whole words when swiping backspace

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
@@ -20,6 +20,7 @@ import helium314.keyboard.latin.common.Constants
 import helium314.keyboard.latin.common.InputPointers
 import helium314.keyboard.latin.common.combiningRange
 import helium314.keyboard.latin.common.moveStepsToCharCount
+import helium314.keyboard.latin.common.moveWordStepsToCharCount
 import helium314.keyboard.latin.define.ProductionFlags
 import helium314.keyboard.latin.inputlogic.InputLogic
 import helium314.keyboard.latin.settings.Settings
@@ -198,7 +199,7 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
     override fun onMoveDeletePointer(steps: Int) {
         inputLogic.finishInput()
         val end = connection.expectedSelectionEnd
-        val actualSteps = actualSteps(steps)
+        val actualSteps = if (Settings.getValues().mSwipeDeleteByWord) wordSteps(steps) else actualSteps(steps)
         val start = connection.expectedSelectionStart + actualSteps
         if (start > end) return
         gestureMoveBackHaptics()
@@ -209,6 +210,12 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
         val text = if (steps > 0) connection.getSelectedText(0) ?: return steps
         else connection.getTextBeforeCursor(-steps * 4, 0) ?: return steps
         return moveStepsToCharCount(text, steps)
+    }
+
+    private fun wordSteps(steps: Int): Int {
+        val text = if (steps > 0) connection.getSelectedText(0) ?: return steps
+        else connection.getTextBeforeCursor(maxOf(50, -steps * 20), 0) ?: return steps
+        return moveWordStepsToCharCount(text, steps)
     }
 
     override fun onUpWithDeletePointerActive() {

--- a/app/src/main/java/helium314/keyboard/latin/common/StringUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/common/StringUtils.kt
@@ -303,6 +303,42 @@ fun moveStepsToCharCount(text: CharSequence, steps: Int): Int {
     }
 }
 
+/** translates a move of [steps] words in [text] to character count, skipping whitespace/punctuation tokens */
+fun moveWordStepsToCharCount(text: CharSequence, steps: Int): Int {
+    if (steps == 0) return 0
+    val str = text.toString()
+    val iterator = BreakIterator.getWordInstance(Locale.ROOT)
+    iterator.setText(str)
+    if (steps > 0) {
+        var wordsLeft = steps
+        var segStart = 0
+        var segEnd = iterator.next()
+        while (segEnd != BreakIterator.DONE) {
+            if (str.substring(segStart, segEnd).any { it.isLetterOrDigit() }) {
+                wordsLeft--
+                if (wordsLeft <= 0) return segEnd
+            }
+            segStart = segEnd
+            segEnd = iterator.next()
+        }
+        return str.length
+    } else {
+        var wordsLeft = -steps
+        var segEnd = str.length
+        iterator.last()
+        var segStart = iterator.previous()
+        while (segStart != BreakIterator.DONE) {
+            if (str.substring(segStart, segEnd).any { it.isLetterOrDigit() }) {
+                wordsLeft--
+                if (wordsLeft <= 0) return segStart - str.length
+            }
+            segEnd = segStart
+            segStart = iterator.previous()
+        }
+        return -str.length
+    }
+}
+
 fun String.splitOnWhitespace() = SpacedTokens(this).toList()
 
 fun stripTrailingSeparatorsAndConnectors(word: String, spacingAndPunctuations: SpacingAndPunctuations): String {

--- a/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
@@ -102,6 +102,7 @@ object Defaults {
     @JvmField
     val PREF_SPACE_VERTICAL_SWIPE = KeyboardActionListener.SwipeAction.NONE.name
     const val PREF_DELETE_SWIPE = true
+    const val PREF_SWIPE_DELETE_BY_WORD = false
     const val PREF_AUTOSPACE_AFTER_PUNCTUATION = false
     const val PREF_AUTOSPACE_AFTER_SUGGESTION = true
     const val PREF_AUTOSPACE_AFTER_GESTURE_TYPING = true

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -111,6 +111,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_SPACE_HORIZONTAL_SWIPE = "horizontal_space_swipe";
     public static final String PREF_SPACE_VERTICAL_SWIPE = "vertical_space_swipe";
     public static final String PREF_DELETE_SWIPE = "delete_swipe";
+    public static final String PREF_SWIPE_DELETE_BY_WORD = "swipe_delete_by_word";
     public static final String PREF_AUTOSPACE_AFTER_PUNCTUATION = "autospace_after_punctuation";
     public static final String PREF_AUTOSPACE_AFTER_SUGGESTION = "autospace_after_suggestion";
     public static final String PREF_AUTOSPACE_AFTER_GESTURE_TYPING = "autospace_after_gesture_typing";

--- a/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
@@ -85,6 +85,7 @@ public class SettingsValues {
     public final int mTouchpadSensitivity;
     public final boolean mTouchpadEdgeScroll;
     public final boolean mDeleteSwipeEnabled;
+    public final boolean mSwipeDeleteByWord;
     public final boolean mAutospaceAfterPunctuation;
     public final boolean mAutospaceAfterSuggestion;
     public final boolean mAutospaceAfterGestureTyping;
@@ -272,6 +273,7 @@ public class SettingsValues {
             Defaults.PREF_TOUCHPAD_SENSITIVITY);
         mTouchpadEdgeScroll = prefs.getBoolean(Settings.PREF_TOUCHPAD_EDGE_SCROLL, Defaults.PREF_TOUCHPAD_EDGE_SCROLL);
         mDeleteSwipeEnabled = prefs.getBoolean(Settings.PREF_DELETE_SWIPE, Defaults.PREF_DELETE_SWIPE);
+        mSwipeDeleteByWord = prefs.getBoolean(Settings.PREF_SWIPE_DELETE_BY_WORD, Defaults.PREF_SWIPE_DELETE_BY_WORD);
         mAutospaceAfterPunctuation = prefs.getBoolean(Settings.PREF_AUTOSPACE_AFTER_PUNCTUATION, Defaults.PREF_AUTOSPACE_AFTER_PUNCTUATION);
         mAutospaceAfterSuggestion = prefs.getBoolean(Settings.PREF_AUTOSPACE_AFTER_SUGGESTION, Defaults.PREF_AUTOSPACE_AFTER_SUGGESTION);
         mAutospaceAfterGestureTyping = prefs.getBoolean(Settings.PREF_AUTOSPACE_AFTER_GESTURE_TYPING, Defaults.PREF_AUTOSPACE_AFTER_GESTURE_TYPING);

--- a/app/src/main/java/helium314/keyboard/settings/screens/AdvancedScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/AdvancedScreen.kt
@@ -75,6 +75,8 @@ fun AdvancedSettingsScreen(
         if (Settings.readVerticalSpaceSwipe(prefs) == KeyboardActionListener.SwipeAction.TOUCHPAD_MODE)
             Settings.PREF_TOUCHPAD_EDGE_SCROLL else null,
         Settings.PREF_DELETE_SWIPE,
+        if (prefs.getBoolean(Settings.PREF_DELETE_SWIPE, Defaults.PREF_DELETE_SWIPE))
+            Settings.PREF_SWIPE_DELETE_BY_WORD else null,
         Settings.PREF_SPACE_TO_CHANGE_LANG,
         Settings.PREFS_LONG_PRESS_SYMBOLS_FOR_NUMPAD,
         Settings.PREF_ENABLE_EMOJI_ALT_PHYSICAL_KEY,
@@ -160,6 +162,9 @@ fun createAdvancedSettings(context: Context) = listOf(
     },
     Setting(context, Settings.PREF_DELETE_SWIPE, R.string.delete_swipe, R.string.delete_swipe_summary) {
         SwitchPreference(it, Defaults.PREF_DELETE_SWIPE)
+    },
+    Setting(context, Settings.PREF_SWIPE_DELETE_BY_WORD, R.string.swipe_delete_by_word, R.string.swipe_delete_by_word_summary) {
+        SwitchPreference(it, Defaults.PREF_SWIPE_DELETE_BY_WORD)
     },
     Setting(context, Settings.PREF_SPACE_TO_CHANGE_LANG,
         R.string.prefs_long_press_keyboard_to_change_lang,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -210,6 +210,10 @@
     <string name="delete_swipe">Delete swipe</string>
     <!-- Description for "delete_swipe" option. -->
     <string name="delete_swipe_summary">Perform a swipe from the delete key to select and remove bigger portions of text at once</string>
+    <!-- Preferences item for swipe-delete-by-word option. -->
+    <string name="swipe_delete_by_word">Swipe backspace deletes words</string>
+    <!-- Description for "swipe_delete_by_word" option. -->
+    <string name="swipe_delete_by_word_summary">When swiping from the backspace key, select and delete whole words instead of individual characters</string>
     <!-- Preferences item and dialog title for backup and restore -->
     <string name="backup_restore_title">Backup and restore</string>
     <!-- Message for backup and restore dialog -->


### PR DESCRIPTION
Includes Gboard functionality: swipe left/right from backspace key deletes WORDS, instead of character-by-character.

I only rarely use GitHub for PRs.. not sure if I'm not following the guide or anything. I'm also a layman programmer, but it works for my purposes. Mostly creating this so I can attach to issue 1289. This might be a nice bandaid for them, if they're so inclined to rebuild the .apk