### PR TITLE
Add image functionality to clipboard history

### DIFF
--- a/app/src/debug/res/values/clip_provider.xml
+++ b/app/src/debug/res/values/clip_provider.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="clipboard_provider_authority" translatable="false">helium314.keyboard.debug.clipprovider</string>
+</resources>

--- a/app/src/debugNoMinify/res/values/clip_provider.xml
+++ b/app/src/debugNoMinify/res/values/clip_provider.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="clipboard_provider_authority" translatable="false">helium314.keyboard.debug.clipprovider</string>
+</resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -107,6 +107,17 @@ SPDX-License-Identifier: Apache-2.0 AND GPL-3.0-only
             </intent-filter>
         </receiver>
 
+        <!-- for pasting file from internal clipboard -->
+        <provider android:name="helium314.keyboard.latin.database.ClipboardContentProvider"
+            android:authorities="@string/clipboard_provider_authority"
+            android:enabled="true"
+            android:grantUriPermissions="true"
+            android:exported="false">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/clipboard_provider_path"/>
+        </provider>
+
         <!-- necessary for sending mail attachments, remove when data gathering phase is done (end of 2026 latest) -->
         <provider android:name="helium314.keyboard.settings.screens.gesturedata.GestureFileProvider"
             android:authorities="@string/gesture_data_provider_authority"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -107,7 +107,7 @@ SPDX-License-Identifier: Apache-2.0 AND GPL-3.0-only
             </intent-filter>
         </receiver>
 
-        <!-- for pasting file from internal clipboard -->
+        <!-- for pasting files from internal clipboard -->
         <provider android:name="helium314.keyboard.latin.database.ClipboardContentProvider"
             android:authorities="@string/clipboard_provider_authority"
             android:enabled="true"

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListener.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListener.java
@@ -8,6 +8,8 @@ package helium314.keyboard.keyboard;
 
 import android.view.KeyEvent;
 
+import androidx.core.view.inputmethod.InputContentInfoCompat;
+
 import helium314.keyboard.event.HapticEvent;
 import helium314.keyboard.latin.common.Constants;
 import helium314.keyboard.latin.common.InputPointers;
@@ -66,6 +68,9 @@ public interface KeyboardActionListener {
      * @param text the string of characters to be registered.
      */
     void onTextInput(String text);
+
+    /** sends content (URI and description) */
+    void onContent(InputContentInfoCompat content);
 
     /**
      * Called when user started batch input.
@@ -135,6 +140,8 @@ public interface KeyboardActionListener {
         public void onCodeInput(int primaryCode, int x, int y, boolean isKeyRepeat) {}
         @Override
         public void onTextInput(String text) {}
+        @Override
+        public void onContent(InputContentInfoCompat content) {}
         @Override
         public void onStartBatchInput() {}
         @Override

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
@@ -129,7 +129,7 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
         val editorInfo = latinIME.currentInputEditorInfo
         val editorMimeTypes = EditorInfoCompat.getContentMimeTypes(editorInfo)
         if (editorMimeTypes.any { content.description.hasMimeType(it) }) {
-            if (connection.commitContent(content, editorInfo)) return
+            connection.commitContent(content, editorInfo)
         } else if (editorMimeTypes.isEmpty()) { // make the fallback optional?
             latinIME.clipboardHistoryManager.pasteWithoutChangingClips(content)
         }

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
@@ -130,7 +130,7 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
         val editorMimeTypes = EditorInfoCompat.getContentMimeTypes(editorInfo)
         if (editorMimeTypes.any { content.description.hasMimeType(it) }) {
             if (connection.commitContent(content, editorInfo)) return
-        } else if (editorMimeTypes.isEmpty()) {
+        } else if (editorMimeTypes.isEmpty()) { // make the fallback optional?
             latinIME.clipboardHistoryManager.pasteWithoutChangingClips(content)
         }
     }

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
@@ -6,6 +6,7 @@ import android.util.SparseArray
 import android.view.KeyEvent
 import android.view.inputmethod.InputMethodSubtype
 import androidx.core.util.forEach
+import androidx.core.view.inputmethod.EditorInfoCompat
 import androidx.core.view.inputmethod.InputContentInfoCompat
 import helium314.keyboard.event.Event
 import helium314.keyboard.event.HangulEventDecoder
@@ -125,8 +126,13 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
     override fun onTextInput(text: String?) = latinIME.onTextInput(text)
 
     override fun onContent(content: InputContentInfoCompat) {
-        if (connection.commitContent(content, latinIME.currentInputEditorInfo)) return
-        latinIME.clipboardHistoryManager.pasteWithoutChangingClips(content)
+        val editorInfo = latinIME.currentInputEditorInfo
+        val editorMimeTypes = EditorInfoCompat.getContentMimeTypes(editorInfo)
+        if (editorMimeTypes.any { content.description.hasMimeType(it) }) {
+            if (connection.commitContent(content, editorInfo)) return
+        } else if (editorMimeTypes.isEmpty()) {
+            latinIME.clipboardHistoryManager.pasteWithoutChangingClips(content)
+        }
     }
 
     override fun onStartBatchInput() = latinIME.onStartBatchInput()

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
@@ -6,6 +6,7 @@ import android.util.SparseArray
 import android.view.KeyEvent
 import android.view.inputmethod.InputMethodSubtype
 import androidx.core.util.forEach
+import androidx.core.view.inputmethod.InputContentInfoCompat
 import helium314.keyboard.event.Event
 import helium314.keyboard.event.HangulEventDecoder
 import helium314.keyboard.event.HapticEvent
@@ -122,6 +123,11 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
     }
 
     override fun onTextInput(text: String?) = latinIME.onTextInput(text)
+
+    override fun onContent(content: InputContentInfoCompat) {
+        if (connection.commitContent(content, latinIME.currentInputEditorInfo)) return
+        latinIME.clipboardHistoryManager.pasteWithoutChangingClips(content)
+    }
 
     override fun onStartBatchInput() = latinIME.onStartBatchInput()
 

--- a/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardAdapter.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardAdapter.kt
@@ -81,15 +81,13 @@ class ClipboardAdapter(
             if (historyEntry == null) return
             itemView.tag = historyEntry.id
             if (historyEntry.filename != null) {
-                val (image, description) = historyEntry.getImageAndDescription(contentImageView.context)
-                contentImageView.setImageDrawable(image)
-                contentTextView.text = description
+                historyEntry.setImageAndDescription(contentImageView, contentTextView)
             } else {
                 contentTextView.text = historyEntry.text?.take(1000) // truncate displayed text for performance reasons
             }
             pinnedIconView.visibility = if (historyEntry.isPinned) View.VISIBLE else View.GONE
             contentImageView.visibility = if (historyEntry.filename != null) View.VISIBLE else View.GONE
-            contentTextView.visibility = if (contentTextView.text.isNullOrBlank()) View.GONE else View.VISIBLE
+            contentTextView.visibility = if (contentTextView.text != null) View.VISIBLE else View.GONE
         }
 
         @SuppressLint("ClickableViewAccessibility")

--- a/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardAdapter.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardAdapter.kt
@@ -50,7 +50,8 @@ class ClipboardAdapter(
     ) : RecyclerView.ViewHolder(view), View.OnClickListener, View.OnTouchListener, View.OnLongClickListener {
 
         private val pinnedIconView: ImageView
-        private val contentView: TextView
+        private val contentTextView: TextView
+        private val contentImageView: ImageView
 
         init {
             view.apply {
@@ -65,20 +66,30 @@ class ClipboardAdapter(
                 visibility = View.GONE
                 setImageResource(pinnedIconResId)
             }
-            contentView = view.findViewById<TextView>(R.id.clipboard_entry_content).apply {
+            contentTextView = view.findViewById<TextView>(R.id.clipboard_entry_text_content).apply {
                 typeface = itemTypeFace
                 setTextColor(itemTextColor)
                 setTextSize(TypedValue.COMPLEX_UNIT_PX, itemTextSize)
             }
+            contentImageView = view.findViewById(R.id.clipboard_entry_image_content)
             clipboardLayoutParams.setItemProperties(view)
             val colors = Settings.getValues().mColors
             colors.setColor(pinnedIconView, ColorType.CLIPBOARD_PIN)
         }
 
         fun setContent(historyEntry: ClipboardHistoryEntry?) {
-            itemView.tag = historyEntry?.id
-            contentView.text = historyEntry?.text?.take(1000) // truncate displayed text for performance reasons
-            pinnedIconView.visibility = if (historyEntry?.isPinned == true) View.VISIBLE else View.GONE
+            if (historyEntry == null) return
+            itemView.tag = historyEntry.id
+            if (historyEntry.filename != null) {
+                val (image, description) = historyEntry.getImageAndDescription(contentImageView.context)
+                contentImageView.setImageDrawable(image)
+                contentTextView.text = description
+            } else {
+                contentTextView.text = historyEntry.text?.take(1000) // truncate displayed text for performance reasons
+            }
+            pinnedIconView.visibility = if (historyEntry.isPinned) View.VISIBLE else View.GONE
+            contentImageView.visibility = if (historyEntry.filename != null) View.VISIBLE else View.GONE
+            contentTextView.visibility = if (contentTextView.text.isNullOrBlank()) View.GONE else View.VISIBLE
         }
 
         @SuppressLint("ClickableViewAccessibility")

--- a/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardAdapter.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardAdapter.kt
@@ -87,7 +87,7 @@ class ClipboardAdapter(
             }
             pinnedIconView.visibility = if (historyEntry.isPinned) View.VISIBLE else View.GONE
             contentImageView.visibility = if (historyEntry.filename != null) View.VISIBLE else View.GONE
-            contentTextView.visibility = if (contentTextView.text != null) View.VISIBLE else View.GONE
+            contentTextView.visibility = if (contentTextView.text.isNullOrEmpty()) View.GONE else View.VISIBLE
         }
 
         @SuppressLint("ClickableViewAccessibility")

--- a/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardHistoryView.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardHistoryView.kt
@@ -235,7 +235,8 @@ class ClipboardHistoryView @JvmOverloads constructor(
 
     override fun onKeyUp(clipId: Long) {
         val clipContent = clipboardHistoryManager.getHistoryEntryContent(clipId)
-        keyboardActionListener.onTextInput(clipContent?.text)
+        if (clipContent?.filename != null) keyboardActionListener.onContent(clipContent.getContentInfo(context))
+        else keyboardActionListener.onTextInput(clipContent?.text)
         keyboardActionListener.onReleaseKey(KeyCode.NOT_SPECIFIED, false)
         if (Settings.getValues().mAlphaAfterClipHistoryEntry)
             keyboardActionListener.onCodeInput(KeyCode.ALPHA, Constants.NOT_A_COORDINATE, Constants.NOT_A_COORDINATE, false)

--- a/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryEntry.kt
+++ b/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryEntry.kt
@@ -33,9 +33,8 @@ class ClipboardHistoryEntry(
         return result
     }
 
-    fun getContentInfo(context: Context): InputContentInfoCompat {
-        return InputContentInfoCompat(getContentUri(context)!!, ClipDescription(text, mimeTypes?.toTypedArray()), null)
-    }
+    fun getContentInfo(context: Context): InputContentInfoCompat =
+        InputContentInfoCompat(getContentUri(context)!!, ClipDescription(text, mimeTypes?.toTypedArray()), null)
 
     fun getContentUri(context: Context) = filename?.let { FileProvider.getUriForFile(
         context,

--- a/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryEntry.kt
+++ b/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryEntry.kt
@@ -43,6 +43,7 @@ class ClipboardHistoryEntry(
         File(ClipboardDao.clipFilesDir, it)
     ) }
 
+    // todo: if slow we could decode images it in a coroutine, or use cached preview images
     @SuppressLint("SetTextI18n")
     fun setImageAndDescription(imageView: ImageView, textView: TextView) {
         if (mimeTypes == null || filename == null) return // should never happen

--- a/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryEntry.kt
+++ b/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryEntry.kt
@@ -48,8 +48,14 @@ class ClipboardHistoryEntry(
         if (mimeTypes == null || filename == null) return // should never happen
         try {
             val path = File(ClipboardDao.clipFilesDir, filename).absolutePath
-            // looks like decoded size is adjusted automatically to fit screen
-            val bitmap = BitmapFactory.decodeFile(path)
+            val opt = BitmapFactory.Options()
+            opt.inJustDecodeBounds = true
+            BitmapFactory.decodeFile(path, opt)
+            // reduce size of images larger than the screen, only needs to fit half screen width
+            val scale = opt.outWidth / (imageView.resources.displayMetrics.widthPixels * 2)
+            opt.inSampleSize = scale
+            opt.inJustDecodeBounds = false
+            val bitmap = BitmapFactory.decodeFile(path, opt)
             if (bitmap != null) {
                 imageView.setImageBitmap(bitmap)
                 textView.text = null

--- a/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryEntry.kt
+++ b/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryEntry.kt
@@ -2,16 +2,17 @@
 
 package helium314.keyboard.latin
 
+import android.annotation.SuppressLint
 import android.content.ClipDescription
 import android.content.Context
 import android.graphics.BitmapFactory
-import android.graphics.drawable.Drawable
 import android.os.Build
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.core.content.FileProvider
 import helium314.keyboard.latin.common.ColorType
 import helium314.keyboard.latin.settings.Settings
 import helium314.keyboard.latin.utils.Log
-import androidx.core.graphics.drawable.toDrawable
 import androidx.core.view.inputmethod.InputContentInfoCompat
 import helium314.keyboard.latin.database.ClipboardDao
 import java.io.File
@@ -42,22 +43,32 @@ class ClipboardHistoryEntry(
         File(ClipboardDao.clipFilesDir, it)
     ) }
 
-    fun getImageAndDescription(context: Context): Pair<Drawable?, String> {
-        if (mimeTypes == null || filename == null) return null to "" // should never happen
+    @SuppressLint("SetTextI18n")
+    fun setImageAndDescription(imageView: ImageView, textView: TextView) {
+        if (mimeTypes == null || filename == null) return // should never happen
         try {
             val path = File(ClipboardDao.clipFilesDir, filename).absolutePath
             // looks like decoded size is adjusted automatically to fit screen
-            return BitmapFactory.decodeFile(path).toDrawable(context.resources) to ""
+            val bitmap = BitmapFactory.decodeFile(path)
+            if (bitmap != null) {
+                imageView.setImageBitmap(bitmap)
+                textView.text = null
+                return
+            }
         } catch (e: Exception) {
             Log.w("ClipboardHistoryEntry", "could not load image for clip $id", e)
         }
+        val description = if (text.isNullOrBlank()) ""
+            else "\n" + textView.context.getString(R.string.item_description, text)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            val info = context.contentResolver.getTypeInfo(mimeTypes[0])
-            val drawable = info.icon.loadDrawable(context)
-            if (drawable != null)
-                Settings.getValues().mColors.setColor(drawable, ColorType.EMOJI_CATEGORY) // todo: colorType?
-            return drawable to (info.label.toString() + if (text.isNullOrBlank()) "" else "\n$text")
+            val info = imageView.context.contentResolver.getTypeInfo(mimeTypes[0])
+            info.icon.setTint(Settings.getValues().mColors.get(ColorType.EMOJI_CATEGORY))
+            imageView.setImageIcon(info.icon)
+            textView.text = textView.context.getString(R.string.item_type, info.label.toString()) + description
+            return
         }
-        return null to mimeTypes.first() + if (text.isNullOrBlank()) "" else "\n$text"
+        imageView.setImageResource(R.drawable.ic_dictionary)
+        Settings.getValues().mColors.setColor(imageView, ColorType.EMOJI_CATEGORY)
+        textView.text = textView.context.getString(R.string.item_type, mimeTypes.first()) + description
     }
 }

--- a/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryEntry.kt
+++ b/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryEntry.kt
@@ -2,18 +2,62 @@
 
 package helium314.keyboard.latin
 
+import android.content.ClipDescription
+import android.content.Context
+import android.graphics.BitmapFactory
+import android.graphics.drawable.Drawable
+import android.os.Build
+import androidx.core.content.FileProvider
+import helium314.keyboard.latin.common.ColorType
 import helium314.keyboard.latin.settings.Settings
+import helium314.keyboard.latin.utils.Log
+import androidx.core.graphics.drawable.toDrawable
+import androidx.core.view.inputmethod.InputContentInfoCompat
+import helium314.keyboard.latin.database.ClipboardDao
+import java.io.File
 
 class ClipboardHistoryEntry(
     val id: Long,
     var timeStamp: Long,
     var isPinned: Boolean,
-    val text: String
+    val text: String?,
+    val filename: String?,
+    val mimeTypes: List<String>?
 ) : Comparable<ClipboardHistoryEntry> {
+    // for display order
     override fun compareTo(other: ClipboardHistoryEntry): Int {
         val result = other.isPinned.compareTo(isPinned)
         if (result == 0) return other.timeStamp.compareTo(timeStamp)
         if (Settings.getValues()?.mClipboardHistoryPinnedFirst == false) return -result
         return result
+    }
+
+    fun getContentInfo(context: Context): InputContentInfoCompat {
+        return InputContentInfoCompat(getContentUri(context)!!, ClipDescription(text, mimeTypes?.toTypedArray()), null)
+    }
+
+    fun getContentUri(context: Context) = filename?.let { FileProvider.getUriForFile(
+        context,
+        context.getString(R.string.clipboard_provider_authority),
+        File(ClipboardDao.clipFilesDir, it)
+    ) }
+
+    fun getImageAndDescription(context: Context): Pair<Drawable?, String> {
+        if (mimeTypes == null || filename == null) return null to "" // should never happen
+        try {
+            val path = File(ClipboardDao.clipFilesDir, filename).absolutePath
+            // looks like decoded size is adjusted automatically to fit screen
+            return BitmapFactory.decodeFile(path).toDrawable(context.resources) to ""
+        } catch (e: Exception) {
+            Log.w("ClipboardHistoryEntry", "could not load image for clip $id", e)
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val info = context.contentResolver.getTypeInfo(mimeTypes[0])
+            val drawable = info.icon.loadDrawable(context)
+            if (drawable != null)
+                Settings.getValues().mColors.setColor(drawable, ColorType.EMOJI_CATEGORY) // todo: colorType?
+            return drawable to (info.label.toString() + if (text.isNullOrBlank()) "" else "\n$text")
+        }
+        return null to mimeTypes.first() + if (text.isNullOrBlank()) "" else "\n$text"
     }
 }

--- a/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
+++ b/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
@@ -191,9 +191,9 @@ class ClipboardHistoryManager(
         val textView = binding.clipboardSuggestionText
         val clipIcon = latinIME.mKeyboardSwitcher.keyboard.mIconsSet.getIconDrawable(ToolbarKey.PASTE.name.lowercase())
         textView.setCompoundDrawablesRelativeWithIntrinsicBounds(clipIcon, null, null, null)
+        val inputType = editorInfo?.inputType ?: InputType.TYPE_NULL
         if (hasText) {
             if (TextUtils.isEmpty(content)) return null
-            val inputType = editorInfo?.inputType ?: InputType.TYPE_NULL
             if (InputTypeUtils.isNumberInputType(inputType) && !content.isValidNumber()) return null
             KeyboardTypeface.applyToTextView(textView)
             textView.text = (if (isClipSensitive(inputType)) "*".repeat(content.length.coerceAtMost(200)) else content)
@@ -209,13 +209,13 @@ class ClipboardHistoryManager(
         textView.setOnClickListener(onClickListener)
 
         if (hasImage) {
+            if (InputTypeUtils.isNumberInputType(inputType)) return null
             val imageView = binding.clipboardSuggestionImage
             imageView.isVisible = true
             try {
                 imageView.setImageURI(clipItem.uri)
             } catch (e: Exception) {
-                Log.w(TAG, "error setting clipboard image", e)
-                // happens with SecurityException: Permission Denial
+                Log.w(TAG, "error setting clipboard image", e) // happens with SecurityException: Permission Denial
                 return null
             }
             imageView.setOnClickListener(onClickListener)
@@ -248,13 +248,15 @@ class ClipboardHistoryManager(
 
     companion object {
         private val TAG = "ClipboardHistoryManager"
+
         // avoid showing the current suggestion because it has been dismissed or pasted
         private var dontShowCurrentSuggestion: Boolean = false
+
         const val RECENT_TIME_MILLIS = 3 * 60 * 1000L // 3 minutes (for clipboard suggestions)
 
         private fun maySaveFromUri(uri: Uri?, context: Context): Boolean {
-            val maxSize = context.prefs().getInt(Settings.PREF_CLIPBOARD_FILES_SIZE, Defaults.PREF_CLIPBOARD_FILES_SIZE)
-            val saveUriData = context.prefs().getBoolean(Settings.PREF_CLIPBOARD_FILES, Defaults.PREF_CLIPBOARD_FILES)
+            val maxSize = context.prefs().getInt(Settings.PREF_CLIPBOARD_FILES_SIZE_LIMIT, Defaults.PREF_CLIPBOARD_FILES_SIZE_LIMIT)
+            val saveUriData = context.prefs().getBoolean(Settings.PREF_CLIPBOARD_USE_FILES, Defaults.PREF_CLIPBOARD_USE_FILES)
             if (uri == null || !saveUriData) return false
             try {
                 val cursor = context.contentResolver.query(uri, arrayOf(OpenableColumns.SIZE), null, null)
@@ -262,8 +264,7 @@ class ClipboardHistoryManager(
                 val size = cursor.getLong(0)
                 return size <= maxSize * 1000000 // maxSize is megabytes
             } catch (e: Exception) {
-                Log.w(TAG, "error checking clip size", e)
-                // happens with SecurityException: Permission Denial, so returning true doesn't make sense
+                Log.w(TAG, "error checking clip size", e) // happens with SecurityException: Permission Denial
                 return false
             }
         }

--- a/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
+++ b/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
@@ -77,7 +77,6 @@ class ClipboardHistoryManager(
         val timeStamp = ClipboardManagerCompat.getClipTimestamp(clipData)
 
         // todo
-        //  test backup / restore
         //  inline clip with view (PR 2312)
         if (description.hasMimeType("text/*")) {
             val content = clipItem.coerceToText(latinIME)

--- a/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
+++ b/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
@@ -2,25 +2,39 @@
 
 package helium314.keyboard.latin
 
+import android.content.ClipData
+import android.content.ClipDescription
 import android.content.ClipboardManager
 import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
 import android.text.InputType
 import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
+import androidx.core.view.inputmethod.InputContentInfoCompat
 import androidx.core.view.isGone
 import helium314.keyboard.keyboard.KeyboardTypeface
 import helium314.keyboard.compat.ClipboardManagerCompat
+import helium314.keyboard.event.Event
 import helium314.keyboard.event.HapticEvent
 import helium314.keyboard.keyboard.internal.keyboard_parser.floris.KeyCode
 import helium314.keyboard.latin.common.ColorType
+import helium314.keyboard.latin.common.Constants
 import helium314.keyboard.latin.common.isValidNumber
 import helium314.keyboard.latin.database.ClipboardDao
 import helium314.keyboard.latin.databinding.ClipboardSuggestionBinding
+import helium314.keyboard.latin.settings.Defaults
+import helium314.keyboard.latin.settings.Settings
 import helium314.keyboard.latin.utils.InputTypeUtils
+import helium314.keyboard.latin.utils.Log
 import helium314.keyboard.latin.utils.ToolbarKey
+import helium314.keyboard.latin.utils.prefs
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 class ClipboardHistoryManager(
         private val latinIME: LatinIME
@@ -29,6 +43,7 @@ class ClipboardHistoryManager(
     private lateinit var clipboardManager: ClipboardManager
     private var clipboardSuggestionView: View? = null
     private var clipboardDao: ClipboardDao? = null
+    private var tempPrimaryClip = false
 
     fun onCreate() {
         clipboardManager = latinIME.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
@@ -50,14 +65,65 @@ class ClipboardHistoryManager(
         }
     }
 
+    // todo for later
+    //  setting whether to store sensitive clip data?
+    //  care about other clip items than first?
     private fun fetchPrimaryClip() {
+        if (tempPrimaryClip) return // avoid updating history
         val clipData = clipboardManager.primaryClip ?: return
-        if (clipData.itemCount == 0 || clipData.description?.hasMimeType("text/*") == false) return
-        clipData.getItemAt(0)?.let { clipItem ->
-            val timeStamp = ClipboardManagerCompat.getClipTimestamp(clipData)
+        if (clipData.itemCount == 0) return
+        val clipItem = clipData.getItemAt(0) ?: return
+        val description = clipData.description ?: return
+        val timeStamp = ClipboardManagerCompat.getClipTimestamp(clipData)
+
+        // todo
+        //  test backup / restore
+        //  inline clip with view (PR 2312)
+        if (description.hasMimeType("text/*")) {
             val content = clipItem.coerceToText(latinIME)
             if (TextUtils.isEmpty(content)) return
             clipboardDao?.addClip(timeStamp, false, content.toString())
+        } else if (maySaveFromUri(clipItem.uri, latinIME)) {
+            clipboardDao?.addClipUri(timeStamp, false, clipItem.uri, description, latinIME)
+        }
+    }
+
+    // fallback method because in some apps we cannot commitContent, but KeyEvent.KEYCODE_PASTE works fine (if the content is the primary clip)
+    // actually we do change the primary clip, but (try to) revert immediately
+    fun pasteWithoutChangingClips(content: InputContentInfoCompat) {
+        Log.d(TAG, "Committing content did not work, trying fallback via system clipboard")
+        val primaryClip = clipboardManager.primaryClip
+        val tempClip = ClipData(content.description, ClipData.Item(content.contentUri))
+        tempPrimaryClip = true
+        clipboardManager.setPrimaryClip(tempClip)
+        latinIME.onEvent(Event.createSoftwareKeypressEvent(KeyCode.CLIPBOARD_PASTE, 0,
+            Constants.NOT_A_COORDINATE, Constants.NOT_A_COORDINATE, false))
+        tempPrimaryClip = false
+        if (primaryClip == null)
+            return
+        // we need to wait a little before switching back to the original primary clip
+        // a. it can happen that we switch back before the pasting has started, in that case we only past the primary clip
+        // b. if we switch while the clip is pasted, it might crash the app (tested with joplin and logseq)
+        GlobalScope.launch {
+            delay(500)
+            try {
+                clipboardManager.setPrimaryClip(primaryClip)
+            } catch (e: Exception) {
+                Log.i(TAG, "could not go back to old primary clip", e)
+                // happens wen the clip was a file
+                // try to find it in out clipboard entries
+                val clip = clipboardDao?.getAll()?.firstOrNull { it.timeStamp == ClipboardManagerCompat.getClipTimestamp(primaryClip) }
+                if (clip?.filename != null)
+                    clipboardManager.setPrimaryClip(ClipData(
+                        ClipDescription(clip.text, clip.mimeTypes?.toTypedArray()),
+                        ClipData.Item(clip.getContentUri(latinIME))
+                    ))
+                else if (clip != null)
+                    clipboardManager.setPrimaryClip(ClipData(
+                        ClipDescription("", arrayOf("text/*")),
+                        ClipData.Item(clip.text)
+                    ))
+            }
         }
     }
 
@@ -96,12 +162,6 @@ class ClipboardHistoryManager(
         clipboardDao?.listener = listener
     }
 
-    fun retrieveClipboardContent(): CharSequence {
-        val clipData = clipboardManager.primaryClip ?: return ""
-        if (clipData.itemCount == 0) return ""
-        return clipData.getItemAt(0)?.coerceToText(latinIME) ?: ""
-    }
-
     private fun isClipSensitive(inputType: Int): Boolean {
         ClipboardManagerCompat.getClipSensitivity(clipboardManager.primaryClip?.description)?.let { return it }
         return InputTypeUtils.isPasswordInputType(inputType)
@@ -111,6 +171,7 @@ class ClipboardHistoryManager(
         // maybe no need to create a new view
         // but a cache has to consider a few possible changes, so better don't implement without need
         clipboardSuggestionView = null
+        Log.e("clipboard", "something")
 
         // get the content, or return null
         if (!latinIME.mSettings.current.mSuggestClipboardContent) return null
@@ -130,8 +191,7 @@ class ClipboardHistoryManager(
         val binding = ClipboardSuggestionBinding.inflate(LayoutInflater.from(latinIME), parent, false)
         val textView = binding.clipboardSuggestionText
         KeyboardTypeface.applyToTextView(textView)
-        textView.text = (if (isClipSensitive(inputType)) "*".repeat(content.length) else content)
-            .take(200) // truncate displayed text for performance reasons
+        textView.text = (if (isClipSensitive(inputType)) "*".repeat(content.length.coerceAtMost(200)) else content)
         val clipIcon = latinIME.mKeyboardSwitcher.keyboard.mIconsSet.getIconDrawable(ToolbarKey.PASTE.name.lowercase())
         textView.setCompoundDrawablesRelativeWithIntrinsicBounds(clipIcon, null, null, null)
         textView.setOnClickListener {
@@ -166,7 +226,24 @@ class ClipboardHistoryManager(
     }
 
     companion object {
+        private val TAG = "ClipboardHistoryManager"
         private var dontShowCurrentSuggestion: Boolean = false
         const val RECENT_TIME_MILLIS = 3 * 60 * 1000L // 3 minutes (for clipboard suggestions)
+
+        private fun maySaveFromUri(uri: Uri?, context: Context): Boolean {
+            val maxSize = context.prefs().getInt(Settings.PREF_CLIPBOARD_FILES_SIZE, Defaults.PREF_CLIPBOARD_FILES_SIZE)
+            val saveUriData = context.prefs().getBoolean(Settings.PREF_CLIPBOARD_FILES, Defaults.PREF_CLIPBOARD_FILES)
+            if (uri == null || !saveUriData) return false
+            try {
+                val cursor = context.contentResolver.query(uri, arrayOf(OpenableColumns.SIZE), null, null)
+                if (cursor?.moveToFirst() != true) return false
+                val size = cursor.getLong(0)
+                return size <= maxSize
+            } catch (e: Exception) {
+                Log.w(TAG, "error checking clip size", e)
+                // happens with SecurityException: Permission Denial, so returning true doesn't make sense
+                return false
+            }
+        }
     }
 }

--- a/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
+++ b/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
@@ -16,6 +16,7 @@ import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import androidx.core.view.inputmethod.InputContentInfoCompat
 import androidx.core.view.isGone
+import androidx.core.view.isVisible
 import helium314.keyboard.keyboard.KeyboardTypeface
 import helium314.keyboard.compat.ClipboardManagerCompat
 import helium314.keyboard.event.Event
@@ -76,8 +77,6 @@ class ClipboardHistoryManager(
         val description = clipData.description ?: return
         val timeStamp = ClipboardManagerCompat.getClipTimestamp(clipData)
 
-        // todo
-        //  inline clip with view (PR 2312)
         if (description.hasMimeType("text/*")) {
             val content = clipItem.coerceToText(latinIME)
             if (TextUtils.isEmpty(content)) return
@@ -178,28 +177,50 @@ class ClipboardHistoryManager(
         if (dontShowCurrentSuggestion) return null
         if (parent == null) return null
         val clipData = clipboardManager.primaryClip ?: return null
-        if (clipData.itemCount == 0 || clipData.description?.hasMimeType("text/*") == false) return null
+        if (clipData.itemCount == 0) return null
         val clipItem = clipData.getItemAt(0) ?: return null
+        val hasText = clipData.description?.hasMimeType("text/*") == true
+        val hasImage = clipData.description?.hasMimeType("image/*") == true && clipItem.uri != null
+        if (!hasText && !hasImage) return null
         val timeStamp = ClipboardManagerCompat.getClipTimestamp(clipData)
         if (System.currentTimeMillis() - timeStamp > RECENT_TIME_MILLIS) return null
         val content = clipItem.coerceToText(latinIME)
-        if (TextUtils.isEmpty(content)) return null
-        val inputType = editorInfo?.inputType ?: InputType.TYPE_NULL
-        if (InputTypeUtils.isNumberInputType(inputType) && !content.isValidNumber()) return null
 
         // create the view
         val binding = ClipboardSuggestionBinding.inflate(LayoutInflater.from(latinIME), parent, false)
         val textView = binding.clipboardSuggestionText
-        KeyboardTypeface.applyToTextView(textView)
-        textView.text = (if (isClipSensitive(inputType)) "*".repeat(content.length.coerceAtMost(200)) else content)
         val clipIcon = latinIME.mKeyboardSwitcher.keyboard.mIconsSet.getIconDrawable(ToolbarKey.PASTE.name.lowercase())
         textView.setCompoundDrawablesRelativeWithIntrinsicBounds(clipIcon, null, null, null)
-        textView.setOnClickListener {
+        if (hasText) {
+            if (TextUtils.isEmpty(content)) return null
+            val inputType = editorInfo?.inputType ?: InputType.TYPE_NULL
+            if (InputTypeUtils.isNumberInputType(inputType) && !content.isValidNumber()) return null
+            KeyboardTypeface.applyToTextView(textView)
+            textView.text = (if (isClipSensitive(inputType)) "*".repeat(content.length.coerceAtMost(200)) else content)
+        }
+        val onClickListener = View.OnClickListener {
             dontShowCurrentSuggestion = true
-            latinIME.onTextInput(content.toString())
+            if (hasText) latinIME.onTextInput(content.toString())
+            else latinIME.onEvent(Event.createSoftwareKeypressEvent(KeyCode.CLIPBOARD_PASTE, 0,
+                Constants.NOT_A_COORDINATE, Constants.NOT_A_COORDINATE, false))
             AudioAndHapticFeedbackManager.getInstance().performHapticAndAudioFeedback(KeyCode.NOT_SPECIFIED, it, HapticEvent.KEY_PRESS)
             binding.root.isGone = true
         }
+        textView.setOnClickListener(onClickListener)
+
+        if (hasImage) {
+            val imageView = binding.clipboardSuggestionImage
+            imageView.isVisible = true
+            try {
+                imageView.setImageURI(clipItem.uri)
+            } catch (e: Exception) {
+                Log.w(TAG, "error setting clipboard image", e)
+                // happens with SecurityException: Permission Denial
+                return null
+            }
+            imageView.setOnClickListener(onClickListener)
+        }
+
         val closeButton = binding.clipboardSuggestionClose
         closeButton.setImageDrawable(latinIME.mKeyboardSwitcher.keyboard.mIconsSet.getIconDrawable(ToolbarKey.CLOSE_HISTORY.name.lowercase()))
         closeButton.setOnClickListener { removeClipboardSuggestion() }

--- a/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
+++ b/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
@@ -87,10 +87,11 @@ class ClipboardHistoryManager(
         }
     }
 
-    // fallback method because in some apps we cannot commitContent, but KeyEvent.KEYCODE_PASTE works fine (if the content is the primary clip)
-    // actually we do change the primary clip, but (try to) revert immediately
+    // fallback method because in some apps there is no supported mime type and commitContend does nothing,
+    // but KeyEvent.KEYCODE_PASTE for pasting from primary clip works fine
+    // (actually we do change the primary clip, but (try to) revert immediately)
     fun pasteWithoutChangingClips(content: InputContentInfoCompat) {
-        Log.d(TAG, "Committing content did not work, trying fallback via system clipboard")
+        Log.d(TAG, "trying fallback pasting with system clipboard")
         val primaryClip = clipboardManager.primaryClip
         val tempClip = ClipData(content.description, ClipData.Item(content.contentUri))
         tempPrimaryClip = true

--- a/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
+++ b/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
@@ -171,7 +171,6 @@ class ClipboardHistoryManager(
         // maybe no need to create a new view
         // but a cache has to consider a few possible changes, so better don't implement without need
         clipboardSuggestionView = null
-        Log.e("clipboard", "something")
 
         // get the content, or return null
         if (!latinIME.mSettings.current.mSuggestClipboardContent) return null
@@ -227,6 +226,7 @@ class ClipboardHistoryManager(
 
     companion object {
         private val TAG = "ClipboardHistoryManager"
+        // avoid showing the current suggestion because it has been dismissed or pasted
         private var dontShowCurrentSuggestion: Boolean = false
         const val RECENT_TIME_MILLIS = 3 * 60 * 1000L // 3 minutes (for clipboard suggestions)
 
@@ -238,7 +238,7 @@ class ClipboardHistoryManager(
                 val cursor = context.contentResolver.query(uri, arrayOf(OpenableColumns.SIZE), null, null)
                 if (cursor?.moveToFirst() != true) return false
                 val size = cursor.getLong(0)
-                return size <= maxSize
+                return size <= maxSize * 1000000 // maxSize is megabytes
             } catch (e: Exception) {
                 Log.w(TAG, "error checking clip size", e)
                 // happens with SecurityException: Permission Denial, so returning true doesn't make sense

--- a/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
+++ b/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
@@ -104,6 +104,7 @@ class ClipboardHistoryManager(
         // we need to wait a little before switching back to the original primary clip
         // a. it can happen that we switch back before the pasting has started, in that case we only past the primary clip
         // b. if we switch while the clip is pasted, it might crash the app (tested with joplin and logseq)
+        // todo: replacing the current primary clip is far from ideal, try finding a different way
         GlobalScope.launch {
             delay(500)
             try {

--- a/app/src/main/java/helium314/keyboard/latin/RichInputConnection.java
+++ b/app/src/main/java/helium314/keyboard/latin/RichInputConnection.java
@@ -1181,12 +1181,10 @@ public final class RichInputConnection implements PrivateCommandPerformer {
         return mIC.requestCursorUpdates(cursorUpdateMode);
     }
 
-    // doesn't work in MANY apps that support normal clipboard pasting -> fallback in KeyboardActionListenerImpl
-    public boolean commitContent(InputContentInfoCompat contentInfo, @NonNull EditorInfo editorInfo) {
+    // doesn't work in many apps that support normal clipboard pasting, possibly just because they don't have mime types in editorInfo
+    public void commitContent(InputContentInfoCompat contentInfo, @NonNull EditorInfo editorInfo) {
         mIC = mParent.getCurrentInputConnection();
-        if (!isConnected()) {
-            return false;
-        }
-        return InputConnectionCompat.commitContent(mIC, editorInfo, contentInfo, InputConnectionCompat.INPUT_CONTENT_GRANT_READ_URI_PERMISSION, null);
+        if (isConnected())
+            InputConnectionCompat.commitContent(mIC, editorInfo, contentInfo, InputConnectionCompat.INPUT_CONTENT_GRANT_READ_URI_PERMISSION, null);
     }
 }

--- a/app/src/main/java/helium314/keyboard/latin/RichInputConnection.java
+++ b/app/src/main/java/helium314/keyboard/latin/RichInputConnection.java
@@ -10,6 +10,7 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.inputmethodservice.InputMethodService;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.SystemClock;
@@ -25,13 +26,18 @@ import helium314.keyboard.latin.utils.Log;
 import android.view.KeyEvent;
 import android.view.inputmethod.CompletionInfo;
 import android.view.inputmethod.CorrectionInfo;
+import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.ExtractedText;
 import android.view.inputmethod.ExtractedTextRequest;
 import android.view.inputmethod.InputConnection;
+import android.view.inputmethod.InputContentInfo;
 import android.view.inputmethod.InputMethodManager;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.view.inputmethod.EditorInfoCompat;
+import androidx.core.view.inputmethod.InputConnectionCompat;
+import androidx.core.view.inputmethod.InputContentInfoCompat;
 
 import helium314.keyboard.latin.common.Constants;
 import helium314.keyboard.latin.common.StringUtils;
@@ -45,6 +51,7 @@ import helium314.keyboard.latin.utils.NgramContextUtils;
 import helium314.keyboard.latin.utils.StatsUtils;
 import helium314.keyboard.latin.utils.TextRange;
 
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -1176,5 +1183,14 @@ public final class RichInputConnection implements PrivateCommandPerformer {
         final int cursorUpdateMode = (enableMonitor ? InputConnection.CURSOR_UPDATE_MONITOR : 0)
             | (requestImmediateCallback ? InputConnection.CURSOR_UPDATE_IMMEDIATE : 0);
         return mIC.requestCursorUpdates(cursorUpdateMode);
+    }
+
+    // doesn't work in MANY apps that support normal clipboard pasting -> fallback in KeyboardActionListenerImpl
+    public boolean commitContent(InputContentInfoCompat contentInfo, @NonNull final EditorInfo editorInfo) {
+        mIC = mParent.getCurrentInputConnection();
+        if (!isConnected()) {
+            return false;
+        }
+        return InputConnectionCompat.commitContent(mIC, editorInfo, contentInfo, InputConnectionCompat.INPUT_CONTENT_GRANT_READ_URI_PERMISSION, null);
     }
 }

--- a/app/src/main/java/helium314/keyboard/latin/RichInputConnection.java
+++ b/app/src/main/java/helium314/keyboard/latin/RichInputConnection.java
@@ -10,7 +10,6 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.inputmethodservice.InputMethodService;
-import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.SystemClock;
@@ -30,12 +29,10 @@ import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.ExtractedText;
 import android.view.inputmethod.ExtractedTextRequest;
 import android.view.inputmethod.InputConnection;
-import android.view.inputmethod.InputContentInfo;
 import android.view.inputmethod.InputMethodManager;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.view.inputmethod.EditorInfoCompat;
 import androidx.core.view.inputmethod.InputConnectionCompat;
 import androidx.core.view.inputmethod.InputContentInfoCompat;
 
@@ -51,7 +48,6 @@ import helium314.keyboard.latin.utils.NgramContextUtils;
 import helium314.keyboard.latin.utils.StatsUtils;
 import helium314.keyboard.latin.utils.TextRange;
 
-import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -1186,7 +1182,7 @@ public final class RichInputConnection implements PrivateCommandPerformer {
     }
 
     // doesn't work in MANY apps that support normal clipboard pasting -> fallback in KeyboardActionListenerImpl
-    public boolean commitContent(InputContentInfoCompat contentInfo, @NonNull final EditorInfo editorInfo) {
+    public boolean commitContent(InputContentInfoCompat contentInfo, @NonNull EditorInfo editorInfo) {
         mIC = mParent.getCurrentInputConnection();
         if (!isConnected()) {
             return false;

--- a/app/src/main/java/helium314/keyboard/latin/common/StringUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/common/StringUtils.kt
@@ -266,13 +266,17 @@ val String.isSingleGrapheme: Boolean get() {
     if (isEmpty()) return false
     if (length == 1) return true
 
-    val iterator = localBreakIterator
-    iterator.setText(this)
-    iterator.next()
-    if (iterator.next() != BreakIterator.DONE) return false
-    // we have a single grapheme, but " 🏼" is detected as single grapheme which we don't want
-    return if ('\uD83C' !in this) true // does not contain skin tone
-    else singleEmojiRegex.matches(this) // single grapheme only if it's a single emoji
+    runCatching {
+        val iterator = localBreakIterator
+        iterator.setText(this)
+        iterator.next()
+        if (iterator.next() != BreakIterator.DONE) return false
+        // we have a single grapheme, but " 🏼" is detected as single grapheme which we don't want
+        return if ('\uD83C' !in this) true // does not contain skin tone
+        else singleEmojiRegex.matches(this) // single grapheme only if it's a single emoji
+    }
+    // got IllegalArgumentException: Invalid index on iterator.next()
+    return false
 }
 
 val String.lastGrapheme: String get() {

--- a/app/src/main/java/helium314/keyboard/latin/database/ClipboardDao.kt
+++ b/app/src/main/java/helium314/keyboard/latin/database/ClipboardDao.kt
@@ -97,7 +97,7 @@ class ClipboardDao private constructor(private val db: Database) {
 
     // keep pinned and the first non-pinned, others can be deleted
     private fun deleteIfSizeExceeded(prefs: SharedPreferences) {
-        val sizeLimit = prefs.getInt(Settings.PREF_CLIPBOARD_FILES_SIZE, Defaults.PREF_CLIPBOARD_FILES_SIZE) * 1000000
+        val sizeLimit = prefs.getInt(Settings.PREF_CLIPBOARD_FILES_SIZE_LIMIT, Defaults.PREF_CLIPBOARD_FILES_SIZE_LIMIT) * 1000000
         var size = 0L
         var keepMin = 1
         val toRemove = mutableListOf<ClipboardHistoryEntry>()
@@ -179,7 +179,7 @@ class ClipboardDao private constructor(private val db: Database) {
         delete(listOf(cache[index]))
     }
 
-    fun delete(entries: List<ClipboardHistoryEntry>) {
+    private fun delete(entries: List<ClipboardHistoryEntry>) {
         if (entries.isEmpty()) return
         cache.removeAll(entries)
         db.writableDatabase.delete(TABLE, "$COLUMN_ID IN (${entries.joinToString(",") { it.id.toString() }})", null)
@@ -220,7 +220,7 @@ class ClipboardDao private constructor(private val db: Database) {
     }
 
     fun cleanupFiles(prefs: SharedPreferences) {
-        if (!prefs.getBoolean(Settings.PREF_CLIPBOARD_FILES, Defaults.PREF_CLIPBOARD_FILES)) {
+        if (!prefs.getBoolean(Settings.PREF_CLIPBOARD_USE_FILES, Defaults.PREF_CLIPBOARD_USE_FILES)) {
             delete(cache.filter { it.filename != null && !it.isPinned })
             return
         }

--- a/app/src/main/java/helium314/keyboard/latin/database/ClipboardDao.kt
+++ b/app/src/main/java/helium314/keyboard/latin/database/ClipboardDao.kt
@@ -18,6 +18,7 @@ import helium314.keyboard.latin.utils.ChecksumCalculator
 import helium314.keyboard.latin.utils.Log
 import helium314.keyboard.latin.utils.prefs
 import java.io.File
+import kotlin.collections.joinToString
 
 /** Class providing cached access to the clipboard table */
 // currently we should not need to worry about synchronizing access (though maybe we could addClip in a coroutine, then it might be relevant)
@@ -67,7 +68,7 @@ class ClipboardDao private constructor(private val db: Database) {
             updateTimestampAt(existingIndex, timestamp)
             return
         }
-        insertNewEntry(timestamp, pinned, text)
+        insertNewEntry(timestamp, pinned, text, null, null, null)
     }
 
     fun addClipUri(timestamp: Long, pinned: Boolean, uri: Uri, description: ClipDescription, context: Context) {
@@ -89,24 +90,9 @@ class ClipboardDao private constructor(private val db: Database) {
             return
         }
         tempFile.renameTo(file)
-
-        val mimeTypes = description.getMimeTypes()
-        val cv = ContentValues(4)
-        cv.put(COLUMN_TIMESTAMP, timestamp)
-        cv.put(COLUMN_PINNED, pinned)
-        cv.put(COLUMN_TEXT, description.label?.toString())
-        cv.put(COLUMN_FILE, file.name)
-        // § should be a safe separator, not allowed in mime types: https://datatracker.ietf.org/doc/html/rfc6838#section-4.2
-        cv.put(COLUMN_MIME_TYPE, mimeTypes.joinToString("$"))
-        val rowId = db.writableDatabase.insert(TABLE, null, cv)
-
-        val entry = ClipboardHistoryEntry(rowId, timestamp, pinned, description.label?.toString(), file.name, mimeTypes)
-        deleteIfSizeExceeded(context.prefs())
-        cache.add(entry)
-        cache.sort()
-        listener?.onClipInserted(cache.indexOf(entry))
         // we could try getting a thumbnail using context.contentResolver.loadThumbnail(uri, Size(a, b), null)
         // but currently we don't cache them anyway, so no use for that
+        insertNewEntry(timestamp, pinned, description.label?.toString(), file.name, description.getMimeTypes(), context)
     }
 
     // keep pinned and the first non-pinned, others can be deleted
@@ -133,14 +119,20 @@ class ClipboardDao private constructor(private val db: Database) {
         toRemove.forEach { File(clipFilesDir, it.filename!!).delete() }
     }
 
-    private fun insertNewEntry(timestamp: Long, pinned: Boolean, text: String) {
-        val cv = ContentValues(3)
+    /** only public for restoring backups */
+    fun insertNewEntry(timestamp: Long, pinned: Boolean, text: String?, filename: String?, mimeTypes: List<String>?, context: Context?) {
+        val cv = ContentValues(5)
         cv.put(COLUMN_TIMESTAMP, timestamp)
         cv.put(COLUMN_PINNED, pinned)
         cv.put(COLUMN_TEXT, text)
+        cv.put(COLUMN_FILE, filename)
+        // § should be a safe separator, not allowed in mime types: https://datatracker.ietf.org/doc/html/rfc6838#section-4.2
+        cv.put(COLUMN_MIME_TYPE, mimeTypes?.joinToString("§"))
         val rowId = db.writableDatabase.insert(TABLE, null, cv)
 
-        val entry = ClipboardHistoryEntry(rowId, timestamp, pinned, text, null, null)
+        val entry = ClipboardHistoryEntry(rowId, timestamp, pinned, text, filename, mimeTypes)
+        if (filename != null && context != null)
+            deleteIfSizeExceeded(context.prefs())
         cache.add(entry)
         cache.sort()
         listener?.onClipInserted(cache.indexOf(entry))
@@ -289,7 +281,7 @@ class ClipboardDao private constructor(private val db: Database) {
         private const val COLUMN_PINNED = "PINNED"
         private const val COLUMN_TEXT = "TEXT" // we could enforce unique text, but that's only necessary if we can drop the cache (later)
         private const val COLUMN_FILE = "FILE" // path relative to files dir
-        private const val COLUMN_MIME_TYPE = "MIME_TYPE" // for files
+        private const val COLUMN_MIME_TYPE = "MIME_TYPE" // for files, actually a list of mime types according to clipboard description
         const val CREATE_TABLE = """
             CREATE TABLE $TABLE (
                 $COLUMN_ID INTEGER PRIMARY KEY,

--- a/app/src/main/java/helium314/keyboard/latin/database/ClipboardDao.kt
+++ b/app/src/main/java/helium314/keyboard/latin/database/ClipboardDao.kt
@@ -111,7 +111,7 @@ class ClipboardDao private constructor(private val db: Database) {
 
     // keep pinned and the first non-pinned, others can be deleted
     private fun deleteIfSizeExceeded(prefs: SharedPreferences) {
-        val sizeLimit = prefs.getInt(Settings.PREF_CLIPBOARD_FILES_SIZE, Defaults.PREF_CLIPBOARD_FILES_SIZE)
+        val sizeLimit = prefs.getInt(Settings.PREF_CLIPBOARD_FILES_SIZE, Defaults.PREF_CLIPBOARD_FILES_SIZE) * 1000000
         var size = 0L
         var keepMin = 1
         val toRemove = mutableListOf<ClipboardHistoryEntry>()
@@ -127,8 +127,10 @@ class ClipboardDao private constructor(private val db: Database) {
             }
         }
         if (toRemove.isEmpty()) return
+        Log.i(TAG, "deleting ${toRemove.size} items because size limit is exceeded")
         cache.removeAll(toRemove)
         db.writableDatabase.delete(TABLE, "$COLUMN_ID IN (${toRemove.joinToString(",") { it.id.toString() }})", null)
+        toRemove.forEach { File(clipFilesDir, it.filename!!).delete() }
     }
 
     private fun insertNewEntry(timestamp: Long, pinned: Boolean, text: String) {
@@ -245,24 +247,26 @@ class ClipboardDao private constructor(private val db: Database) {
     }
 
     fun cleanupFiles(prefs: SharedPreferences) {
-        val files = clipFilesDir.listFiles()?.toMutableList() ?: return
         if (!prefs.getBoolean(Settings.PREF_CLIPBOARD_FILES, Defaults.PREF_CLIPBOARD_FILES)) {
-            files.forEach { it.delete() }
             cache.filter { it.filename != null && !it.isPinned }.forEach {
                 cache.remove(it)
                 db.writableDatabase.delete(TABLE, "$COLUMN_ID = ${it.id}", null)
+                File(clipFilesDir, it.filename!!).delete()
             }
             return
         }
 
+        val files = clipFilesDir.listFiles()?.toMutableList() ?: return
         val fnames = files.mapTo(HashSet()) { it.name }
         val entries = cache.filter { it.filename != null }
         val enames = entries.mapTo(HashSet()) { it.filename }
 
         val filesToRemove = files.filter { it.name !in enames }
         val entriesToRemove = entries.filter { it.filename!! !in fnames }
-        if (filesToRemove.isEmpty() && entriesToRemove.isEmpty())
+        if (filesToRemove.isEmpty() && entriesToRemove.isEmpty()) {
+            deleteIfSizeExceeded(prefs)
             return
+        }
 
         Log.w(TAG, "deleting ${filesToRemove.size} files and ${entriesToRemove.size} clipboard entries")
         filesToRemove.forEach { it.delete() }

--- a/app/src/main/java/helium314/keyboard/latin/database/ClipboardDao.kt
+++ b/app/src/main/java/helium314/keyboard/latin/database/ClipboardDao.kt
@@ -112,11 +112,7 @@ class ClipboardDao private constructor(private val db: Database) {
                 else toRemove.add(it)
             }
         }
-        if (toRemove.isEmpty()) return
-        Log.i(TAG, "deleting ${toRemove.size} items because size limit is exceeded")
-        cache.removeAll(toRemove)
-        db.writableDatabase.delete(TABLE, "$COLUMN_ID IN (${toRemove.joinToString(",") { it.id.toString() }})", null)
-        toRemove.forEach { File(clipFilesDir, it.filename!!).delete() }
+        delete(toRemove)
     }
 
     /** only public for restoring backups */
@@ -180,10 +176,14 @@ class ClipboardDao private constructor(private val db: Database) {
 
     // RecyclerView initiates this, so we don't call listener (or we'll get an IndexOutOfRangeException from RecyclerView)
     fun deleteClipAt(index: Int) {
-        val entry = cache[index]
-        cache.remove(entry)
-        entry.filename?.let { File(clipFilesDir, it).delete() }
-        db.writableDatabase.delete(TABLE, "$COLUMN_ID = ${entry.id}", null)
+        delete(listOf(cache[index]))
+    }
+
+    fun delete(entries: List<ClipboardHistoryEntry>) {
+        if (entries.isEmpty()) return
+        cache.removeAll(entries)
+        db.writableDatabase.delete(TABLE, "$COLUMN_ID IN (${entries.joinToString(",") { it.id.toString() }})", null)
+        entries.forEach { if (it.filename != null) File(clipFilesDir, it.filename).delete() }
     }
 
     fun clearOldClips(now: Boolean = false) {
@@ -197,38 +197,19 @@ class ClipboardDao private constructor(private val db: Database) {
         if (retentionTime > 120) return
         val minTime = System.currentTimeMillis() - retentionTime * 60 * 1000L
         val toRemove = cache.filter { it.timeStamp < minTime && !it.isPinned }
-        if (toRemove.isEmpty())
-            return
-
-        toRemove.forEach {
-            cache.remove(it)
-            if (it.filename != null)
-                File(clipFilesDir, it.filename).delete()
-        }
-
-        db.writableDatabase.delete(TABLE, "$COLUMN_TIMESTAMP < $minTime AND $COLUMN_PINNED = 0", null)
+        delete(toRemove)
     }
 
     fun clearNonPinned() {
-        if (listener != null) {
-            val indicesToRemove = mutableListOf<Int>()
-            cache.forEachIndexed { idx, clip ->
-                if (!clip.isPinned)
-                    indicesToRemove.add(idx)
-            }
-            if (indicesToRemove.isEmpty())
-                return // nothing to remove
-            val toRemove = cache.filter { !it.isPinned }
-            toRemove.forEach {
-                cache.remove(it)
-                if (it.filename != null)
-                    File(clipFilesDir, it.filename).delete()
-            }
-            listener?.onClipsRemoved(indicesToRemove[0], indicesToRemove.size)
-        } else if (!cache.removeAll { !it.isPinned }) {
-            return // no listener, nothing to remove
+        val indicesToRemove = mutableListOf<Int>()
+        cache.forEachIndexed { idx, clip ->
+            if (!clip.isPinned)
+                indicesToRemove.add(idx)
         }
-        db.writableDatabase.delete(TABLE, "$COLUMN_PINNED = 0", null)
+        if (indicesToRemove.isEmpty())
+            return // nothing to remove
+        delete(cache.filter { !it.isPinned })
+        listener?.onClipsRemoved(indicesToRemove[0], indicesToRemove.size)
     }
 
     fun clear() {
@@ -240,11 +221,7 @@ class ClipboardDao private constructor(private val db: Database) {
 
     fun cleanupFiles(prefs: SharedPreferences) {
         if (!prefs.getBoolean(Settings.PREF_CLIPBOARD_FILES, Defaults.PREF_CLIPBOARD_FILES)) {
-            cache.filter { it.filename != null && !it.isPinned }.forEach {
-                cache.remove(it)
-                db.writableDatabase.delete(TABLE, "$COLUMN_ID = ${it.id}", null)
-                File(clipFilesDir, it.filename!!).delete()
-            }
+            delete(cache.filter { it.filename != null && !it.isPinned })
             return
         }
 
@@ -262,10 +239,7 @@ class ClipboardDao private constructor(private val db: Database) {
 
         Log.w(TAG, "deleting ${filesToRemove.size} files and ${entriesToRemove.size} clipboard entries")
         filesToRemove.forEach { it.delete() }
-        entriesToRemove.forEach {
-            cache.remove(it)
-            db.writableDatabase.delete(TABLE, "$COLUMN_ID = ${it.id}", null)
-        }
+        delete(entriesToRemove)
 
         deleteIfSizeExceeded(prefs)
     }

--- a/app/src/main/java/helium314/keyboard/latin/database/ClipboardDao.kt
+++ b/app/src/main/java/helium314/keyboard/latin/database/ClipboardDao.kt
@@ -244,11 +244,11 @@ class ClipboardDao private constructor(private val db: Database) {
         db.writableDatabase.delete(TABLE, null, null)
     }
 
-    private fun cleanupFiles(prefs: SharedPreferences) {
+    fun cleanupFiles(prefs: SharedPreferences) {
         val files = clipFilesDir.listFiles()?.toMutableList() ?: return
         if (!prefs.getBoolean(Settings.PREF_CLIPBOARD_FILES, Defaults.PREF_CLIPBOARD_FILES)) {
             files.forEach { it.delete() }
-            cache.filter { it.filename != null }.forEach {
+            cache.filter { it.filename != null && !it.isPinned }.forEach {
                 cache.remove(it)
                 db.writableDatabase.delete(TABLE, "$COLUMN_ID = ${it.id}", null)
             }

--- a/app/src/main/java/helium314/keyboard/latin/database/ClipboardDao.kt
+++ b/app/src/main/java/helium314/keyboard/latin/database/ClipboardDao.kt
@@ -1,24 +1,23 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package helium314.keyboard.latin.database
 
+import android.content.ClipDescription
 import android.content.ContentValues
 import android.content.Context
+import android.content.SharedPreferences
+import android.net.Uri
 import android.os.SystemClock
+import android.webkit.MimeTypeMap
+import androidx.core.content.FileProvider
+import androidx.core.database.getStringOrNull
 import helium314.keyboard.latin.ClipboardHistoryEntry
+import helium314.keyboard.latin.common.FileUtils
+import helium314.keyboard.latin.settings.Defaults
 import helium314.keyboard.latin.settings.Settings
+import helium314.keyboard.latin.utils.ChecksumCalculator
 import helium314.keyboard.latin.utils.Log
-
-/*
- possible extension for later: allow non-text
- setting whether to allow it at all (because it could be slow with large files)
- separate retention time setting
- add mime type column
- add file name column
- add hash column (sha 256) for quick unique check (check full content on hash conflict)
- more sophisticated content loading: some getContent that reads the file, with cache
- async file reads and writes
- caches should be dropped on low memory
- */
+import helium314.keyboard.latin.utils.prefs
+import java.io.File
 
 /** Class providing cached access to the clipboard table */
 // currently we should not need to worry about synchronizing access (though maybe we could addClip in a coroutine, then it might be relevant)
@@ -38,7 +37,7 @@ class ClipboardDao private constructor(private val db: Database) {
     private val cache = mutableListOf<ClipboardHistoryEntry>().apply {
         db.readableDatabase.query(
             TABLE,
-            arrayOf(COLUMN_ID, COLUMN_TIMESTAMP, COLUMN_PINNED, COLUMN_TEXT),
+            arrayOf(COLUMN_ID, COLUMN_TIMESTAMP, COLUMN_PINNED, COLUMN_TEXT, COLUMN_FILE, COLUMN_MIME_TYPE),
             null,
             null,
             null,
@@ -46,7 +45,14 @@ class ClipboardDao private constructor(private val db: Database) {
             "$COLUMN_PINNED, $COLUMN_TIMESTAMP DESC" // was only relevant in the initial approach of using a cursor instead of a cache
         ).use {
             while (it.moveToNext()) {
-                add(ClipboardHistoryEntry(it.getLong(0), it.getLong(1), it.getInt(2) != 0, it.getString(3)))
+                add(ClipboardHistoryEntry(
+                    it.getLong(0),
+                    it.getLong(1),
+                    it.getInt(2) != 0,
+                    it.getStringOrNull(3),
+                    it.getStringOrNull(4),
+                    it.getStringOrNull(5)?.split('§')?.filter { it.isNotEmpty() },
+                ))
             }
         }
         sort()
@@ -64,6 +70,67 @@ class ClipboardDao private constructor(private val db: Database) {
         insertNewEntry(timestamp, pinned, text)
     }
 
+    fun addClipUri(timestamp: Long, pinned: Boolean, uri: Uri, description: ClipDescription, context: Context) {
+        clearOldClips()
+        val extension = if (description.mimeTypeCount == 0) ""
+            else ".${MimeTypeMap.getSingleton().getExtensionFromMimeType(description.getMimeType(0))}"
+        val tempFile = File(context.filesDir, "temp_clip")
+        FileUtils.copyContentUriToNewFile(uri, context, tempFile)
+
+        // we set the file name to the sha256 of the content to have virtually unique names and an easy way to find duplicates
+        val sha256 = ChecksumCalculator.checksum(tempFile)
+        val file = File(clipFilesDir, sha256 + extension)
+
+        val existingIndex = cache.indexOfFirst { it.filename == file.name }
+        if (existingIndex >= 0) {
+            if (cache[existingIndex].timeStamp != timestamp)
+                updateTimestampAt(existingIndex, timestamp)
+            tempFile.delete()
+            return
+        }
+        tempFile.renameTo(file)
+
+        val mimeTypes = description.getMimeTypes()
+        val cv = ContentValues(4)
+        cv.put(COLUMN_TIMESTAMP, timestamp)
+        cv.put(COLUMN_PINNED, pinned)
+        cv.put(COLUMN_TEXT, description.label?.toString())
+        cv.put(COLUMN_FILE, file.name)
+        // § should be a safe separator, not allowed in mime types: https://datatracker.ietf.org/doc/html/rfc6838#section-4.2
+        cv.put(COLUMN_MIME_TYPE, mimeTypes.joinToString("$"))
+        val rowId = db.writableDatabase.insert(TABLE, null, cv)
+
+        val entry = ClipboardHistoryEntry(rowId, timestamp, pinned, description.label?.toString(), file.name, mimeTypes)
+        deleteIfSizeExceeded(context.prefs())
+        cache.add(entry)
+        cache.sort()
+        listener?.onClipInserted(cache.indexOf(entry))
+        // we could try getting a thumbnail using context.contentResolver.loadThumbnail(uri, Size(a, b), null)
+        // but currently we don't cache them anyway, so no use for that
+    }
+
+    // keep pinned and the first non-pinned, others can be deleted
+    private fun deleteIfSizeExceeded(prefs: SharedPreferences) {
+        val sizeLimit = prefs.getInt(Settings.PREF_CLIPBOARD_FILES_SIZE, Defaults.PREF_CLIPBOARD_FILES_SIZE)
+        var size = 0L
+        var keepMin = 1
+        val toRemove = mutableListOf<ClipboardHistoryEntry>()
+        cache.forEach {
+            if (it.filename == null) return@forEach
+            val file = File(clipFilesDir, it.filename)
+            size += file.length()
+            if (it.isPinned)
+                return@forEach
+            if (size > sizeLimit) {
+                if (keepMin > 0) --keepMin
+                else toRemove.add(it)
+            }
+        }
+        if (toRemove.isEmpty()) return
+        cache.removeAll(toRemove)
+        db.writableDatabase.delete(TABLE, "$COLUMN_ID IN (${toRemove.joinToString(",") { it.id.toString() }})", null)
+    }
+
     private fun insertNewEntry(timestamp: Long, pinned: Boolean, text: String) {
         val cv = ContentValues(3)
         cv.put(COLUMN_TIMESTAMP, timestamp)
@@ -71,7 +138,7 @@ class ClipboardDao private constructor(private val db: Database) {
         cv.put(COLUMN_TEXT, text)
         val rowId = db.writableDatabase.insert(TABLE, null, cv)
 
-        val entry = ClipboardHistoryEntry(rowId, timestamp, pinned, text)
+        val entry = ClipboardHistoryEntry(rowId, timestamp, pinned, text, null, null)
         cache.add(entry)
         cache.sort()
         listener?.onClipInserted(cache.indexOf(entry))
@@ -92,6 +159,8 @@ class ClipboardDao private constructor(private val db: Database) {
     fun getAt(index: Int) = cache[index]
 
     fun get(id: Long) = cache.first { it.id == id }
+
+    fun getAll(): List<ClipboardHistoryEntry> = cache
 
     fun count() = cache.size
 
@@ -119,6 +188,7 @@ class ClipboardDao private constructor(private val db: Database) {
     fun deleteClipAt(index: Int) {
         val entry = cache[index]
         cache.remove(entry)
+        entry.filename?.let { File(clipFilesDir, it).delete() }
         db.writableDatabase.delete(TABLE, "$COLUMN_ID = ${entry.id}", null)
     }
 
@@ -132,8 +202,15 @@ class ClipboardDao private constructor(private val db: Database) {
         val retentionTime = Settings.getValues()?.mClipboardHistoryRetentionTime ?: 121L
         if (retentionTime > 120) return
         val minTime = System.currentTimeMillis() - retentionTime * 60 * 1000L
-        if (!cache.removeAll { it.timeStamp < minTime && !it.isPinned })
-            return // nothing was removed
+        val toRemove = cache.filter { it.timeStamp < minTime && !it.isPinned }
+        if (toRemove.isEmpty())
+            return
+
+        toRemove.forEach {
+            cache.remove(it)
+            if (it.filename != null)
+                File(clipFilesDir, it.filename).delete()
+        }
 
         db.writableDatabase.delete(TABLE, "$COLUMN_TIMESTAMP < $minTime AND $COLUMN_PINNED = 0", null)
     }
@@ -147,7 +224,12 @@ class ClipboardDao private constructor(private val db: Database) {
             }
             if (indicesToRemove.isEmpty())
                 return // nothing to remove
-            cache.removeAll { !it.isPinned }
+            val toRemove = cache.filter { !it.isPinned }
+            toRemove.forEach {
+                cache.remove(it)
+                if (it.filename != null)
+                    File(clipFilesDir, it.filename).delete()
+            }
             listener?.onClipsRemoved(indicesToRemove[0], indicesToRemove.size)
         } else if (!cache.removeAll { !it.isPinned }) {
             return // no listener, nothing to remove
@@ -162,6 +244,36 @@ class ClipboardDao private constructor(private val db: Database) {
         db.writableDatabase.delete(TABLE, null, null)
     }
 
+    private fun cleanupFiles(prefs: SharedPreferences) {
+        val files = clipFilesDir.listFiles()?.toMutableList() ?: return
+        if (!prefs.getBoolean(Settings.PREF_CLIPBOARD_FILES, Defaults.PREF_CLIPBOARD_FILES)) {
+            files.forEach { it.delete() }
+            cache.filter { it.filename != null }.forEach {
+                cache.remove(it)
+                db.writableDatabase.delete(TABLE, "$COLUMN_ID = ${it.id}", null)
+            }
+            return
+        }
+
+        val fnames = files.mapTo(HashSet()) { it.name }
+        val entries = cache.filter { it.filename != null }
+        val enames = entries.mapTo(HashSet()) { it.filename }
+
+        val filesToRemove = files.filter { it.name !in enames }
+        val entriesToRemove = entries.filter { it.filename!! !in fnames }
+        if (filesToRemove.isEmpty() && entriesToRemove.isEmpty())
+            return
+
+        Log.w(TAG, "deleting ${filesToRemove.size} files and ${entriesToRemove.size} clipboard entries")
+        filesToRemove.forEach { it.delete() }
+        entriesToRemove.forEach {
+            cache.remove(it)
+            db.writableDatabase.delete(TABLE, "$COLUMN_ID = ${it.id}", null)
+        }
+
+        deleteIfSizeExceeded(prefs)
+    }
+
     companion object {
         private const val TAG = "ClipboardDao"
 
@@ -172,6 +284,8 @@ class ClipboardDao private constructor(private val db: Database) {
         private const val COLUMN_TIMESTAMP = "TIMESTAMP"
         private const val COLUMN_PINNED = "PINNED"
         private const val COLUMN_TEXT = "TEXT" // we could enforce unique text, but that's only necessary if we can drop the cache (later)
+        private const val COLUMN_FILE = "FILE" // path relative to files dir
+        private const val COLUMN_MIME_TYPE = "MIME_TYPE" // for files
         const val CREATE_TABLE = """
             CREATE TABLE $TABLE (
                 $COLUMN_ID INTEGER PRIMARY KEY,
@@ -181,17 +295,37 @@ class ClipboardDao private constructor(private val db: Database) {
             )
         """
 
+        const val ADD_FILE_COLUMN = "ALTER TABLE $TABLE ADD COLUMN $COLUMN_FILE TEXT"
+        const val ADD_MIME_TYPE_COLUMN = "ALTER TABLE $TABLE ADD COLUMN $COLUMN_MIME_TYPE TEXT"
+
         private var instance: ClipboardDao? = null
+        lateinit var clipFilesDir: File
+            private set
 
         /** Returns the instance or creates a new one. Returns null if instance can't be created (e.g. no access to db due to device being locked) */
         fun getInstance(context: Context): ClipboardDao? {
             if (instance == null)
                 try {
                     instance = ClipboardDao(Database.getInstance(context))
+                    clipFilesDir = File(context.filesDir, "clipboard")
+                    clipFilesDir.mkdirs()
+                    instance?.cleanupFiles(context.prefs())
                 } catch (e: Throwable) {
                     Log.e(TAG, "can't create ClipboardDao", e)
                 }
             return instance
         }
+
+        private fun ClipDescription.getMimeTypes(): List<String> {
+            val types = mutableListOf<String>()
+            for (i in 0..<mimeTypeCount) {
+                types.add(getMimeType(i))
+            }
+            if (types.isEmpty())
+                types.add("*/*")
+            return types
+        }
     }
 }
+
+class ClipboardContentProvider : FileProvider()

--- a/app/src/main/java/helium314/keyboard/latin/database/Database.kt
+++ b/app/src/main/java/helium314/keyboard/latin/database/Database.kt
@@ -19,11 +19,15 @@ class Database private constructor(context: Context, name: String = NAME) : SQLi
         if (oldVersion <= 1) {
             db.execSQL(GestureDataDao.CREATE_TABLE)
         }
+        if (oldVersion <= 2) {
+            db.execSQL(ClipboardDao.ADD_FILE_COLUMN)
+            db.execSQL(ClipboardDao.ADD_MIME_TYPE_COLUMN)
+        }
     }
 
     companion object {
         private val TAG = Database::class.java.simpleName
-        private const val VERSION = 2
+        private const val VERSION = 3
         const val NAME = "heliboard.db"
         private var instance: Database? = null
         fun getInstance(context: Context): Database {

--- a/app/src/main/java/helium314/keyboard/latin/database/Database.kt
+++ b/app/src/main/java/helium314/keyboard/latin/database/Database.kt
@@ -4,6 +4,7 @@ package helium314.keyboard.latin.database
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
+import androidx.core.database.getStringOrNull
 import androidx.core.database.sqlite.transaction
 import helium314.keyboard.latin.utils.GestureDataDao
 import helium314.keyboard.latin.utils.Log
@@ -49,11 +50,19 @@ class Database private constructor(context: Context, name: String = NAME) : SQLi
                     if (clipDao == null) {
                         Log.e(TAG, "can't transfer clipboard data because ClipboardDao is null")
                     } else {
-                        otherDb.readableDatabase.rawQuery("SELECT TIMESTAMP, PINNED, TEXT FROM CLIPBOARD", null)
+                        otherDb.readableDatabase.rawQuery("SELECT TIMESTAMP, PINNED, TEXT, FILE, MIME_TYPE FROM CLIPBOARD", null)
                             .use {
                                 clipDao.clear()
-                                while (it.moveToNext())
-                                    clipDao.addClip(it.getLong(0), it.getInt(1) != 0, it.getString(2))
+                                while (it.moveToNext()) {
+                                    clipDao.insertNewEntry(
+                                        it.getLong(0),
+                                        it.getInt(1) != 0,
+                                        it.getStringOrNull(2),
+                                        it.getStringOrNull(3),
+                                        it.getStringOrNull(4)?.split("§"),
+                                        null
+                                    )
+                                }
                             }
                     }
                     db.writableDatabase.execSQL("DELETE FROM GESTURE_DATA")

--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -655,18 +655,6 @@ public final class InputLogic {
     }
 
     /**
-     * Handles the action of pasting content from the clipboard.
-     * Retrieves content from the clipboard history manager and commits it to the input connection.
-     *
-     */
-    private void handleClipboardPaste() {
-        final String clipboardContent = mLatinIME.getClipboardHistoryManager().retrieveClipboardContent().toString();
-        if (!clipboardContent.isEmpty()) {
-            mLatinIME.onTextInput(clipboardContent);
-        }
-    }
-
-    /**
      * Handle a functional key event.
      * <p>
      * A functional event is a special key, like delete, shift, emoji, or the settings key.
@@ -720,11 +708,11 @@ public final class InputLogic {
                 // is being handled in {@link KeyboardState#onEvent(Event,int)}.
                 // If disabled, current clipboard content is committed.
                 if (!sv.mClipboardHistoryEnabled) {
-                    handleClipboardPaste();
+                    sendDownUpKeyEvent(KeyEvent.KEYCODE_PASTE);
                 }
                 break;
             case KeyCode.CLIPBOARD_PASTE:
-                handleClipboardPaste();
+                sendDownUpKeyEvent(KeyEvent.KEYCODE_PASTE);
                 break;
             case KeyCode.SHIFT_ENTER:
                 // todo: try using sendDownUpKeyEventWithMetaState() and remove the key code maybe

--- a/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
@@ -150,8 +150,8 @@ object Defaults {
     const val PREF_ENABLE_CLIPBOARD_HISTORY = true
     const val PREF_CLIPBOARD_HISTORY_RETENTION_TIME = 10 // minutes
     const val PREF_CLIPBOARD_HISTORY_PINNED_FIRST = true
-    const val PREF_CLIPBOARD_FILES = true
-    const val PREF_CLIPBOARD_FILES_SIZE = 20 // megabytes
+    const val PREF_CLIPBOARD_USE_FILES = true
+    const val PREF_CLIPBOARD_FILES_SIZE_LIMIT = 20 // megabytes
     const val PREF_ADD_TO_PERSONAL_DICTIONARY = false
     @JvmField
     val PREF_NAVBAR_COLOR = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q

--- a/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
@@ -150,6 +150,8 @@ object Defaults {
     const val PREF_ENABLE_CLIPBOARD_HISTORY = true
     const val PREF_CLIPBOARD_HISTORY_RETENTION_TIME = 10 // minutes
     const val PREF_CLIPBOARD_HISTORY_PINNED_FIRST = true
+    const val PREF_CLIPBOARD_FILES = true
+    const val PREF_CLIPBOARD_FILES_SIZE = 20 // megabytes
     const val PREF_ADD_TO_PERSONAL_DICTIONARY = false
     @JvmField
     val PREF_NAVBAR_COLOR = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -167,6 +167,8 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_ENABLE_CLIPBOARD_HISTORY = "enable_clipboard_history";
     public static final String PREF_CLIPBOARD_HISTORY_RETENTION_TIME = "clipboard_history_retention_time";
     public static final String PREF_CLIPBOARD_HISTORY_PINNED_FIRST = "clipboard_history_pinned_first";
+    public static final String PREF_CLIPBOARD_FILES = "clipboard_history_files";
+    public static final String PREF_CLIPBOARD_FILES_SIZE = "clipboard_history_files_size_limit";
 
     public static final String PREF_ADD_TO_PERSONAL_DICTIONARY = "add_to_personal_dictionary";
     public static final String PREF_NAVBAR_COLOR = "navbar_color";

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -167,8 +167,8 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_ENABLE_CLIPBOARD_HISTORY = "enable_clipboard_history";
     public static final String PREF_CLIPBOARD_HISTORY_RETENTION_TIME = "clipboard_history_retention_time";
     public static final String PREF_CLIPBOARD_HISTORY_PINNED_FIRST = "clipboard_history_pinned_first";
-    public static final String PREF_CLIPBOARD_FILES = "clipboard_history_files";
-    public static final String PREF_CLIPBOARD_FILES_SIZE = "clipboard_history_files_size_limit";
+    public static final String PREF_CLIPBOARD_USE_FILES = "clipboard_histor_usey_files";
+    public static final String PREF_CLIPBOARD_FILES_SIZE_LIMIT = "clipboard_history_files_size_limit";
 
     public static final String PREF_ADD_TO_PERSONAL_DICTIONARY = "add_to_personal_dictionary";
     public static final String PREF_NAVBAR_COLOR = "navbar_color";

--- a/app/src/main/java/helium314/keyboard/settings/preferences/BackupRestorePreference.kt
+++ b/app/src/main/java/helium314/keyboard/settings/preferences/BackupRestorePreference.kt
@@ -348,4 +348,5 @@ private val backupFilePatterns by lazy { listOf(
     "custom_background_image.*".toRegex(),
     "custom_font".toRegex(),
     "custom_emoji_font".toRegex(),
+    "clipboard/.*".toRegex(),
 ) }

--- a/app/src/main/java/helium314/keyboard/settings/screens/PreferencesScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/PreferencesScreen.kt
@@ -79,9 +79,9 @@ fun PreferencesScreen(
         Settings.PREF_ENABLE_CLIPBOARD_HISTORY,
         if (clipboardHistoryEnabled) Settings.PREF_CLIPBOARD_HISTORY_RETENTION_TIME else null,
         if (clipboardHistoryEnabled) Settings.PREF_CLIPBOARD_HISTORY_PINNED_FIRST else null,
-        if (clipboardHistoryEnabled) Settings.PREF_CLIPBOARD_FILES else null,
-        if (clipboardHistoryEnabled && prefs.getBoolean(Settings.PREF_CLIPBOARD_FILES, Defaults.PREF_CLIPBOARD_FILES))
-            Settings.PREF_CLIPBOARD_FILES_SIZE else null,
+        if (clipboardHistoryEnabled) Settings.PREF_CLIPBOARD_USE_FILES else null,
+        if (clipboardHistoryEnabled && prefs.getBoolean(Settings.PREF_CLIPBOARD_USE_FILES, Defaults.PREF_CLIPBOARD_USE_FILES))
+            Settings.PREF_CLIPBOARD_FILES_SIZE_LIMIT else null,
     )
     SearchSettingsScreen(
         onClickBack = onClickBack,
@@ -186,18 +186,18 @@ fun createPreferencesSettings(context: Context) = listOf(
     Setting(context, Settings.PREF_CLIPBOARD_HISTORY_PINNED_FIRST, R.string.clipboard_history_pinned_first) {
         SwitchPreference(it, Defaults.PREF_CLIPBOARD_HISTORY_PINNED_FIRST)
     },
-    Setting(context, Settings.PREF_CLIPBOARD_FILES, R.string.clipboard_history_files) {
+    Setting(context, Settings.PREF_CLIPBOARD_USE_FILES, R.string.clipboard_history_files) {
         val ctx = LocalContext.current
-        SwitchPreference(it, Defaults.PREF_CLIPBOARD_FILES) {
+        SwitchPreference(it, Defaults.PREF_CLIPBOARD_USE_FILES) {
             ClipboardDao.getInstance(ctx)?.cleanupFiles(ctx.prefs())
         }
     },
-    Setting(context, Settings.PREF_CLIPBOARD_FILES_SIZE, R.string.clipboard_history_max_file_size) { setting ->
+    Setting(context, Settings.PREF_CLIPBOARD_FILES_SIZE_LIMIT, R.string.clipboard_history_max_file_size) { setting ->
         val ctx = LocalContext.current
         SliderPreference(
             name = setting.title,
             key = setting.key,
-            default = Defaults.PREF_CLIPBOARD_FILES_SIZE,
+            default = Defaults.PREF_CLIPBOARD_FILES_SIZE_LIMIT,
             description = {
                 if (it > 1000) stringResource(R.string.settings_no_limit)
                 else stringResource(R.string.abbreviation_unit_mb, it.toString())

--- a/app/src/main/java/helium314/keyboard/settings/screens/PreferencesScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/PreferencesScreen.kt
@@ -80,7 +80,8 @@ fun PreferencesScreen(
         if (clipboardHistoryEnabled) Settings.PREF_CLIPBOARD_HISTORY_RETENTION_TIME else null,
         if (clipboardHistoryEnabled) Settings.PREF_CLIPBOARD_HISTORY_PINNED_FIRST else null,
         if (clipboardHistoryEnabled) Settings.PREF_CLIPBOARD_FILES else null,
-        if (clipboardHistoryEnabled) Settings.PREF_CLIPBOARD_FILES_SIZE else null,
+        if (clipboardHistoryEnabled && prefs.getBoolean(Settings.PREF_CLIPBOARD_FILES, Defaults.PREF_CLIPBOARD_FILES))
+            Settings.PREF_CLIPBOARD_FILES_SIZE else null,
     )
     SearchSettingsScreen(
         onClickBack = onClickBack,
@@ -185,10 +186,10 @@ fun createPreferencesSettings(context: Context) = listOf(
     Setting(context, Settings.PREF_CLIPBOARD_HISTORY_PINNED_FIRST, R.string.clipboard_history_pinned_first) {
         SwitchPreference(it, Defaults.PREF_CLIPBOARD_HISTORY_PINNED_FIRST)
     },
-    Setting(context, Settings.PREF_CLIPBOARD_FILES, R.string.clipboard_history_f) {
+    Setting(context, Settings.PREF_CLIPBOARD_FILES, R.string.clipboard_history_files) {
         SwitchPreference(it, Defaults.PREF_CLIPBOARD_FILES)
     },
-    Setting(context, Settings.PREF_CLIPBOARD_FILES_SIZE, R.string.clipboard_history_fs) { setting ->
+    Setting(context, Settings.PREF_CLIPBOARD_FILES_SIZE, R.string.clipboard_history_max_file_size) { setting ->
         val ctx = LocalContext.current
         SliderPreference(
             name = setting.title,
@@ -199,7 +200,7 @@ fun createPreferencesSettings(context: Context) = listOf(
                 else stringResource(R.string.abbreviation_unit_mb, it.toString())
             },
             range = 1f..1001f,
-        ) { ClipboardDao.getInstance(ctx)?.cleanupFiles(true) }
+        ) { ClipboardDao.getInstance(ctx)?.cleanupFiles(ctx.prefs()) }
     },
     Setting(context, Settings.PREF_VIBRATION_DURATION_SETTINGS, R.string.prefs_keypress_vibration_duration_settings) { setting ->
         SliderPreference(

--- a/app/src/main/java/helium314/keyboard/settings/screens/PreferencesScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/PreferencesScreen.kt
@@ -78,7 +78,9 @@ fun PreferencesScreen(
         R.string.settings_category_clipboard_history,
         Settings.PREF_ENABLE_CLIPBOARD_HISTORY,
         if (clipboardHistoryEnabled) Settings.PREF_CLIPBOARD_HISTORY_RETENTION_TIME else null,
-        if (clipboardHistoryEnabled) Settings.PREF_CLIPBOARD_HISTORY_PINNED_FIRST else null
+        if (clipboardHistoryEnabled) Settings.PREF_CLIPBOARD_HISTORY_PINNED_FIRST else null,
+        if (clipboardHistoryEnabled) Settings.PREF_CLIPBOARD_FILES else null,
+        if (clipboardHistoryEnabled) Settings.PREF_CLIPBOARD_FILES_SIZE else null,
     )
     SearchSettingsScreen(
         onClickBack = onClickBack,
@@ -182,6 +184,22 @@ fun createPreferencesSettings(context: Context) = listOf(
     },
     Setting(context, Settings.PREF_CLIPBOARD_HISTORY_PINNED_FIRST, R.string.clipboard_history_pinned_first) {
         SwitchPreference(it, Defaults.PREF_CLIPBOARD_HISTORY_PINNED_FIRST)
+    },
+    Setting(context, Settings.PREF_CLIPBOARD_FILES, R.string.clipboard_history_f) {
+        SwitchPreference(it, Defaults.PREF_CLIPBOARD_FILES)
+    },
+    Setting(context, Settings.PREF_CLIPBOARD_FILES_SIZE, R.string.clipboard_history_fs) { setting ->
+        val ctx = LocalContext.current
+        SliderPreference(
+            name = setting.title,
+            key = setting.key,
+            default = Defaults.PREF_CLIPBOARD_FILES_SIZE,
+            description = {
+                if (it > 1000) stringResource(R.string.settings_no_limit)
+                else stringResource(R.string.abbreviation_unit_mb, it.toString())
+            },
+            range = 1f..1001f,
+        ) { ClipboardDao.getInstance(ctx)?.cleanupFiles(true) }
     },
     Setting(context, Settings.PREF_VIBRATION_DURATION_SETTINGS, R.string.prefs_keypress_vibration_duration_settings) { setting ->
         SliderPreference(

--- a/app/src/main/java/helium314/keyboard/settings/screens/PreferencesScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/PreferencesScreen.kt
@@ -187,7 +187,10 @@ fun createPreferencesSettings(context: Context) = listOf(
         SwitchPreference(it, Defaults.PREF_CLIPBOARD_HISTORY_PINNED_FIRST)
     },
     Setting(context, Settings.PREF_CLIPBOARD_FILES, R.string.clipboard_history_files) {
-        SwitchPreference(it, Defaults.PREF_CLIPBOARD_FILES)
+        val ctx = LocalContext.current
+        SwitchPreference(it, Defaults.PREF_CLIPBOARD_FILES) {
+            ClipboardDao.getInstance(ctx)?.cleanupFiles(ctx.prefs())
+        }
     },
     Setting(context, Settings.PREF_CLIPBOARD_FILES_SIZE, R.string.clipboard_history_max_file_size) { setting ->
         val ctx = LocalContext.current

--- a/app/src/main/res/layout/clipboard_entry_key.xml
+++ b/app/src/main/res/layout/clipboard_entry_key.xml
@@ -30,8 +30,9 @@
         android:orientation="vertical">
         <ImageView
             android:id="@+id/clipboard_entry_image_content"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
             android:adjustViewBounds="true"
             android:visibility="gone"/>
         <TextView

--- a/app/src/main/res/layout/clipboard_entry_key.xml
+++ b/app/src/main/res/layout/clipboard_entry_key.xml
@@ -18,17 +18,28 @@
 
     <!-- Provide audio and haptic feedback by ourselves based on the keyboard settings.
          We just need to ignore the system's audio and haptic feedback settings. -->
-    <TextView
-            android:id="@+id/clipboard_entry_content"
-            android:layout_width="0dp"
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_weight="1"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:layout_marginBottom="6dp"
+        android:layout_marginHorizontal="8dp"
+        android:hapticFeedbackEnabled="false"
+        android:soundEffectsEnabled="false"
+        android:orientation="vertical">
+        <ImageView
+            android:id="@+id/clipboard_entry_image_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:layout_marginTop="4dp"
-            android:layout_marginBottom="6dp"
-            android:layout_marginHorizontal="8dp"
-            android:hapticFeedbackEnabled="false"
-            android:soundEffectsEnabled="false"
+            android:adjustViewBounds="true"
+            android:visibility="gone"/>
+        <TextView
+            android:id="@+id/clipboard_entry_text_content"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:ellipsize="end"
             android:maxLines="4"/>
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/clipboard_suggestion.xml
+++ b/app/src/main/res/layout/clipboard_suggestion.xml
@@ -14,7 +14,7 @@
         android:layout_weight="1"
         android:layout_height="match_parent"
         android:drawablePadding="3dp"
-        android:paddingHorizontal="12dp"
+        android:paddingHorizontal="6dp"
         android:hapticFeedbackEnabled="false"
         android:soundEffectsEnabled="false"
         android:singleLine="true"
@@ -22,6 +22,15 @@
         android:ellipsize="end"
         android:textStyle="bold"
         style="?android:attr/textAppearanceSmall" />
+    <ImageView
+        android:id="@+id/clipboard_suggestion_image"
+        android:adjustViewBounds="true"
+        android:paddingVertical="6dp"
+        android:paddingEnd="6dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:scaleType="centerInside" />
     <ImageView
         android:id="@+id/clipboard_suggestion_close"
         android:contentDescription="@string/spoken_clipboard_suggestion"

--- a/app/src/main/res/values/clip_provider.xml
+++ b/app/src/main/res/values/clip_provider.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="clipboard_provider_authority" translatable="false">helium314.keyboard.clipprovider</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -206,6 +206,12 @@
     <string name="clipboard_history_retention_time">History retention time</string>
     <!-- Preferences item for showing pinned clipboard items first -->
     <string name="clipboard_history_pinned_first">Show pinned items on top</string>
+    <!-- Preferences item for extending the clipboard history to files (images or others) -->
+    <string name="clipboard_history_files">Add images and other files to clipboard history</string>
+    <!-- Preferences item for selecting maximum combined size of clipboard history files -->
+    <string name="clipboard_history_max_file_size">Clipboard size limit</string>
+    <!-- Units abbreviation for size (megabytes) -->
+    <string name="abbreviation_unit_mb">%s MB</string>
     <!-- Preferences item for enabling swipe deletion -->
     <string name="delete_swipe">Delete swipe</string>
     <!-- Description for "delete_swipe" option. -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -210,6 +210,10 @@
     <string name="clipboard_history_files">Add images and other files to clipboard history</string>
     <!-- Preferences item for selecting maximum combined size of clipboard history files -->
     <string name="clipboard_history_max_file_size">Clipboard size limit</string>
+    <!-- Description, used for non-image clipboard files -->
+    <string name="item_description">Description: %s</string>
+    <!-- Type, used for non-image clipboard files -->
+    <string name="item_type">Type: %s</string>
     <!-- Units abbreviation for size (megabytes) -->
     <string name="abbreviation_unit_mb">%s MB</string>
     <!-- Preferences item for enabling swipe deletion -->

--- a/app/src/main/res/xml/clipboard_provider_path.xml
+++ b/app/src/main/res/xml/clipboard_provider_path.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <files-path
+        name="clipboard_data"
+        path="clipboard/"/>
+</paths>


### PR DESCRIPTION
Not just images, actually it's any file in clipboard. But will be mostly used for images I assume.

Missing:
* ~preview image for clipboard suggestion (see #2312)~
* ~non-image files (icons / text!)~
* ~resource strings (currently missing)~
* maybe show a warning if pinned clip size exceeds max allowed size
* testing
  * ~backup / restore~
  * ~changing settings (are files / entries removed accordingly)~
  * ~wider range of apps and file types~
  * ~large files (memory issues?)~