### PR TITLE
Change default popup key on letter ا in Persian language

### DIFF
--- a/app/src/main/assets/locale_key_texts/fa.txt
+++ b/app/src/main/assets/locale_key_texts/fa.txt
@@ -1,7 +1,7 @@
 [popup_keys]
 ه ﻫ|ه‍ هٔ ة
 ی ئ ي ﯨ|ى
-ا !fixedColumnOrder!5 ٱ ء آ أ إ
+ا !fixedColumnOrder!5 آ ء ٱ أ إ
 ت ة
 ک ك
 و ؤ


### PR DESCRIPTION
The former default popup key is mostly used in arabic. This PR changes the default popup key to the letter that is commonly used in persian.
Disclaimer i don't understand persian language but there are at least 2 separate posts that confirm what i said (#2487, #2533).

Closes both of the issues mentioned above

closes #2487
closes #2533