### PR TITLE
Long Press to delete entire word

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -1163,7 +1163,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         final int code = key.getCode();
 
         // Delete Word Feature
-        if (code == KeyCode.DELETE) {
+        if (code == KeyCode.DELETE && Settings.getValues().mDeleteLongPressEnabled) {
             mWordDeleteTickCounter = 0; // Reset the pace counter
 
             // Fire the first word instantly
@@ -1338,11 +1338,12 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         startKeyRepeatTimer(nextRepeatCount); // Tell the timer to queue up the next 50ms tick
 
         // Long Press Delete button (Delete Word)
-        if (code == KeyCode.DELETE) {
+        if (code == KeyCode.DELETE && Settings.getValues().mDeleteLongPressEnabled) {
             mWordDeleteTickCounter++;
 
-            // Only execute on every 4th tick (~200ms)
-            if (mWordDeleteTickCounter % 4 == 0) {
+            // Only execute on every after long press delay
+            if (mWordDeleteTickCounter %
+                Math.round(Settings.getValues().mKeyLongpressTimeout / 50f) == 0) {
                 // FIRE CUSTOM -8 CODE, NOT THE INCOMING -7
                 callListenerOnCodeInput(key, KeyCode.DELETE_WORD, mKeyX, mKeyY, SystemClock.uptimeMillis(), true);
             }

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -50,7 +50,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
     private static final boolean DEBUG_MOVE_EVENT = false;
     private static final boolean DEBUG_LISTENER = false;
     private static final boolean DEBUG_MODE = DebugFlags.DEBUG_ENABLED || DEBUG_EVENT;
-
+    private int mWordDeleteTickCounter = 0;
     static final class PointerTrackerParams {
         public final boolean mKeySelectionByDraggingFinger;
         public final int mTouchNoiseThresholdTime;
@@ -58,6 +58,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         public final int mSuppressKeyPreviewAfterBatchInputDuration;
         public final int mKeyRepeatStartTimeout;
         public final int mKeyRepeatInterval;
+
 
         public PointerTrackerParams(final TypedArray mainKeyboardViewAttr) {
             mKeySelectionByDraggingFinger = mainKeyboardViewAttr.getBoolean(
@@ -1158,9 +1159,24 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             sListener.onReleaseKey(popupKeyCode, false);
             return;
         }
+
         final int code = key.getCode();
+
+        // Delete Word Feature
+        if (code == KeyCode.DELETE) {
+            mWordDeleteTickCounter = 0; // Reset the pace counter
+
+            // Fire the first word instantly
+            sListener.onCodeInput(KeyCode.DELETE_WORD, Constants.NOT_A_COORDINATE, Constants.NOT_A_COORDINATE, false);
+
+            // Tell the static timer proxy to start looping this tracker's onKeyRepeat
+            startKeyRepeatTimer(1);
+            return;
+        }
+        // --------------------------------------
+
         if (code == KeyCode.LANGUAGE_SWITCH
-                || (code == Constants.CODE_SPACE && key.getPopupKeys() == null && Settings.getValues().mSpaceForLangChange)
+            || (code == Constants.CODE_SPACE && key.getPopupKeys() == null && Settings.getValues().mSpaceForLangChange)
         ) {
             // Long pressing the space key invokes IME switcher dialog.
             if (sListener.onCustomRequest(Constants.CUSTOM_CODE_SHOW_INPUT_METHOD_PICKER)) {
@@ -1319,7 +1335,21 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         }
         mIsDetectingGesture = false;
         final int nextRepeatCount = repeatCount + 1;
-        startKeyRepeatTimer(nextRepeatCount);
+        startKeyRepeatTimer(nextRepeatCount); // Tell the timer to queue up the next 50ms tick
+
+        // Long Press Delete button (Delete Word)
+        if (code == KeyCode.DELETE) {
+            mWordDeleteTickCounter++;
+
+            // Only execute on every 4th tick (~200ms)
+            if (mWordDeleteTickCounter % 4 == 0) {
+                // FIRE CUSTOM -8 CODE, NOT THE INCOMING -7
+                callListenerOnCodeInput(key, KeyCode.DELETE_WORD, mKeyX, mKeyY, SystemClock.uptimeMillis(), true);
+            }
+            return;
+        }
+        // -----------------------------------
+
         callListenerOnPressAndCheckKeyboardLayoutChange(key, repeatCount);
         callListenerOnCodeInput(key, code, mKeyX, mKeyY, SystemClock.uptimeMillis(), true);
     }

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/floris/KeyCode.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/floris/KeyCode.kt
@@ -30,7 +30,7 @@ object KeyCode {
     const val FN =                            -5
     const val FN_LOCK =                       -6
     const val DELETE =                        -7
-    //const val DELETE_WORD =                   -8
+    const val DELETE_WORD =                   -8
     //const val FORWARD_DELETE =                -9
     //const val FORWARD_DELETE_WORD =          -10
     const val SHIFT =                        -11

--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -60,6 +60,7 @@ import helium314.keyboard.latin.common.Constants;
 import helium314.keyboard.latin.common.CoordinateUtils;
 import helium314.keyboard.latin.common.InputPointers;
 import helium314.keyboard.latin.common.ViewOutlineProviderUtilsKt;
+import helium314.keyboard.latin.common.StringUtilsKt;
 import helium314.keyboard.latin.define.DebugFlags;
 import helium314.keyboard.latin.inputlogic.InputLogic;
 import helium314.keyboard.latin.personalization.PersonalizationHelper;
@@ -86,6 +87,7 @@ import helium314.keyboard.latin.utils.StatsUtilsManager;
 import helium314.keyboard.latin.utils.SubtypeLocaleUtils;
 import helium314.keyboard.latin.utils.SubtypeSettings;
 import helium314.keyboard.latin.utils.SubtypeState;
+import helium314.keyboard.latin.utils.TextRange;
 import helium314.keyboard.latin.utils.ToolbarMode;
 import helium314.keyboard.settings.SettingsActivity2;
 import kotlin.Unit;
@@ -1412,35 +1414,6 @@ public class LatinIME extends InputMethodService implements
     public void onEvent(@NonNull final Event event) {
         if (KeyCode.VOICE_INPUT == event.getKeyCode()) {
             mRichImm.switchToShortcutIme(this);
-        }
-        if (event.getKeyCode() == KeyCode.DELETE_WORD) {
-
-            // Delete one word immediately.
-            final android.view.inputmethod.InputConnection ic = getCurrentInputConnection();
-            if (ic != null) {
-
-                ic.finishComposingText();
-                // Pick 64 preceding characters
-                CharSequence textBefore = ic.getTextBeforeCursor(64, 0);
-                if (!android.text.TextUtils.isEmpty(textBefore)) {
-                    int length = textBefore.length();
-                    int charsToDelete = 0;
-
-                    // 1. Remove any trailing spaces
-                    while (charsToDelete < length && Character.isWhitespace(textBefore.charAt(length - 1 - charsToDelete))) {
-                        charsToDelete++;
-                    }
-                    // 2. Remove the word
-                    while (charsToDelete < length && !Character.isWhitespace(textBefore.charAt(length - 1 - charsToDelete))) {
-                        charsToDelete++;
-                    }
-                    // 3. Execute
-                    if (charsToDelete > 0) {
-                        ic.deleteSurroundingText(charsToDelete, 0);
-                    }
-                }
-            }
-            return; // Stop here so it doesn't process as normal text!
         }
         final InputTransaction completeInputTransaction =
                 mInputLogic.onCodeInput(mSettings.getCurrent(), event,

--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -1413,6 +1413,33 @@ public class LatinIME extends InputMethodService implements
         if (KeyCode.VOICE_INPUT == event.getKeyCode()) {
             mRichImm.switchToShortcutIme(this);
         }
+        if (event.getKeyCode() == KeyCode.DELETE_WORD) {
+
+            // Delete one word immediately.
+            final android.view.inputmethod.InputConnection ic = getCurrentInputConnection();
+            if (ic != null) {
+                // Pick 64 preceding characters
+                CharSequence textBefore = ic.getTextBeforeCursor(64, 0);
+                if (!android.text.TextUtils.isEmpty(textBefore)) {
+                    int length = textBefore.length();
+                    int charsToDelete = 0;
+
+                    // 1. Remove any trailing spaces
+                    while (charsToDelete < length && Character.isWhitespace(textBefore.charAt(length - 1 - charsToDelete))) {
+                        charsToDelete++;
+                    }
+                    // 2. Remove the word
+                    while (charsToDelete < length && !Character.isWhitespace(textBefore.charAt(length - 1 - charsToDelete))) {
+                        charsToDelete++;
+                    }
+                    // 3. Execute
+                    if (charsToDelete > 0) {
+                        ic.deleteSurroundingText(charsToDelete, 0);
+                    }
+                }
+            }
+            return; // Stop here so it doesn't process as normal text!
+        }
         final InputTransaction completeInputTransaction =
                 mInputLogic.onCodeInput(mSettings.getCurrent(), event,
                         mKeyboardSwitcher.getKeyboardShiftMode(),

--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -1418,6 +1418,8 @@ public class LatinIME extends InputMethodService implements
             // Delete one word immediately.
             final android.view.inputmethod.InputConnection ic = getCurrentInputConnection();
             if (ic != null) {
+
+                ic.finishComposingText();
                 // Pick 64 preceding characters
                 CharSequence textBefore = ic.getTextBeforeCursor(64, 0);
                 if (!android.text.TextUtils.isEmpty(textBefore)) {

--- a/app/src/main/java/helium314/keyboard/latin/common/Constants.java
+++ b/app/src/main/java/helium314/keyboard/latin/common/Constants.java
@@ -222,6 +222,7 @@ public final class Constants {
         case KeyCode.SYMBOL: return "symbol";
         case KeyCode.MULTIPLE_CODE_POINTS: return "text";
         case KeyCode.DELETE: return "delete";
+        case KeyCode.DELETE_WORD: return "deleteWord";
         case KeyCode.SETTINGS: return "settings";
         case KeyCode.VOICE_INPUT: return "shortcut";
         case KeyCode.ACTION_NEXT: return "actionNext";

--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -709,6 +709,12 @@ public final class InputLogic {
                 // Backspace is a functional key, but it affects the contents of the editor.
                 inputTransaction.setDidAffectContents();
                 break;
+
+            case KeyCode.DELETE_WORD:
+                handleDeleteWordEvent(event, inputTransaction, currentKeyboardScript);
+                inputTransaction.setDidAffectContents();
+                break;
+
             case KeyCode.SHIFT:
                 if (KeyboardSwitcher.getInstance().getKeyboard() != null && !KeyboardSwitcher.getInstance().getKeyboard().mId.isAlphabetKeyboard())
                     break; // recapitalization and follow-up code should only trigger for alphabet shift, see #1256
@@ -1440,6 +1446,62 @@ public final class InputLogic {
         }
     }
 
+    /**
+     * Handle a press on the swipe-to-delete-word gesture.
+     * @param event The event to handle.
+     * @param inputTransaction The transaction in progress.
+     */
+    private void handleDeleteWordEvent(final Event event, final InputTransaction inputTransaction,
+                                       final String currentKeyboardScript) {
+
+        mSpaceState = SpaceState.NONE;
+        inputTransaction.requireShiftUpdate(InputTransaction.SHIFT_UPDATE_NOW);
+
+        // Delete the highlighted text, if any
+        if (mConnection.hasSelection()) {
+            final int numCharsDeleted = mConnection.getExpectedSelectionEnd()
+                - mConnection.getExpectedSelectionStart();
+            mConnection.setSelection(mConnection.getExpectedSelectionEnd(),
+                mConnection.getExpectedSelectionEnd());
+            mConnection.deleteTextBeforeCursor(numCharsDeleted);
+            StatsUtils.onBackspaceSelectedText(numCharsDeleted);
+            return;
+        }
+
+        // Clear active composing state (to not skip current word)
+        if (mWordComposer.isComposingWord()) {
+            unlearnWord(mWordComposer.getTypedWord(), inputTransaction.getSettingsValues(),
+                Constants.EVENT_BACKSPACE);
+            resetEntireInputState(mConnection.getExpectedSelectionStart(),
+                mConnection.getExpectedSelectionEnd(), true);
+        }
+        mConnection.finishComposingText();
+
+        // Getting word boundary
+        final TextRange textRange = mConnection.getWordRangeAtCursor(
+            inputTransaction.getSettingsValues().mSpacingAndPunctuations,
+            currentKeyboardScript);
+
+        int charsToDelete = 1;
+        if (textRange != null) {
+            charsToDelete = textRange.getNumberOfCharsInWordBeforeCursor();
+        }
+
+        // For spaces/punctuation, force at least 1 character deletion
+        if (charsToDelete <= 0) {
+            charsToDelete = 1;
+        }
+
+        // Delete word
+        mConnection.deleteTextBeforeCursor(charsToDelete);
+        StatsUtils.onBackspacePressed(charsToDelete);
+
+        // Update the suggestion strip for the new word cursor stopped at
+        if (!mConnection.hasSlowInputConnection() && inputTransaction.getSettingsValues().needsToLookupSuggestions()
+            && inputTransaction.getSettingsValues().mSpacingAndPunctuations.mCurrentLanguageHasSpaces) {
+            restartSuggestionsOnWordTouchedByCursor(inputTransaction.getSettingsValues(), currentKeyboardScript);
+        }
+    }
     String getWordAtCursor(final SettingsValues settingsValues, final String currentKeyboardScript) {
         if (!mConnection.hasSelection()
                 && settingsValues.needsToLookupSuggestions()

--- a/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
@@ -102,6 +102,7 @@ object Defaults {
     @JvmField
     val PREF_SPACE_VERTICAL_SWIPE = KeyboardActionListener.SwipeAction.NONE.name
     const val PREF_DELETE_SWIPE = true
+    const val PREF_DELETE_LONGPRESS = false
     const val PREF_AUTOSPACE_AFTER_PUNCTUATION = false
     const val PREF_AUTOSPACE_AFTER_SUGGESTION = true
     const val PREF_AUTOSPACE_AFTER_GESTURE_TYPING = true

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -115,6 +115,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_SPACE_HORIZONTAL_SWIPE = "horizontal_space_swipe";
     public static final String PREF_SPACE_VERTICAL_SWIPE = "vertical_space_swipe";
     public static final String PREF_DELETE_SWIPE = "delete_swipe";
+    public static final String PREF_DELETE_LONGPRESS = "delete_word_long_press";
     public static final String PREF_AUTOSPACE_AFTER_PUNCTUATION = "autospace_after_punctuation";
     public static final String PREF_AUTOSPACE_AFTER_SUGGESTION = "autospace_after_suggestion";
     public static final String PREF_AUTOSPACE_AFTER_GESTURE_TYPING = "autospace_after_gesture_typing";

--- a/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
@@ -85,6 +85,7 @@ public class SettingsValues {
     public final int mTouchpadSensitivity;
     public final boolean mTouchpadEdgeScroll;
     public final boolean mDeleteSwipeEnabled;
+    public final boolean mDeleteLongPressEnabled;
     public final boolean mAutospaceAfterPunctuation;
     public final boolean mAutospaceAfterSuggestion;
     public final boolean mAutospaceAfterGestureTyping;
@@ -276,6 +277,7 @@ public class SettingsValues {
             Defaults.PREF_TOUCHPAD_SENSITIVITY);
         mTouchpadEdgeScroll = prefs.getBoolean(Settings.PREF_TOUCHPAD_EDGE_SCROLL, Defaults.PREF_TOUCHPAD_EDGE_SCROLL);
         mDeleteSwipeEnabled = prefs.getBoolean(Settings.PREF_DELETE_SWIPE, Defaults.PREF_DELETE_SWIPE);
+        mDeleteLongPressEnabled = prefs.getBoolean(Settings.PREF_DELETE_LONGPRESS, Defaults.PREF_DELETE_LONGPRESS);
         mAutospaceAfterPunctuation = prefs.getBoolean(Settings.PREF_AUTOSPACE_AFTER_PUNCTUATION, Defaults.PREF_AUTOSPACE_AFTER_PUNCTUATION);
         mAutospaceAfterSuggestion = prefs.getBoolean(Settings.PREF_AUTOSPACE_AFTER_SUGGESTION, Defaults.PREF_AUTOSPACE_AFTER_SUGGESTION);
         mAutospaceAfterGestureTyping = prefs.getBoolean(Settings.PREF_AUTOSPACE_AFTER_GESTURE_TYPING, Defaults.PREF_AUTOSPACE_AFTER_GESTURE_TYPING);

--- a/app/src/main/java/helium314/keyboard/settings/screens/AdvancedScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/AdvancedScreen.kt
@@ -75,6 +75,7 @@ fun AdvancedSettingsScreen(
         if (Settings.readVerticalSpaceSwipe(prefs) == KeyboardActionListener.SwipeAction.TOUCHPAD_MODE)
             Settings.PREF_TOUCHPAD_EDGE_SCROLL else null,
         Settings.PREF_DELETE_SWIPE,
+        Settings.PREF_DELETE_LONGPRESS,
         Settings.PREF_SPACE_TO_CHANGE_LANG,
         Settings.PREFS_LONG_PRESS_SYMBOLS_FOR_NUMPAD,
         Settings.PREF_ENABLE_EMOJI_ALT_PHYSICAL_KEY,
@@ -160,6 +161,9 @@ fun createAdvancedSettings(context: Context) = listOf(
     },
     Setting(context, Settings.PREF_DELETE_SWIPE, R.string.delete_swipe, R.string.delete_swipe_summary) {
         SwitchPreference(it, Defaults.PREF_DELETE_SWIPE)
+    },
+    Setting(context, Settings.PREF_DELETE_LONGPRESS, R.string.delete_word_long_press, R.string.delete_word_long_press_summary){
+        SwitchPreference(it, Defaults.PREF_DELETE_LONGPRESS)
     },
     Setting(context, Settings.PREF_SPACE_TO_CHANGE_LANG,
         R.string.prefs_long_press_keyboard_to_change_lang,

--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -111,6 +111,8 @@
     <string name="prefs_keyboard_height_scale">Sleutelbord hoogte-skaal</string>
     <string name="delete_swipe">Skrap met vee</string>
     <string name="show_emoji_key">Emoji sleutel</string>
+    <string name="delete_word_long_press">Skrap woord met langdruk</string>
+    <string name="delete_word_long_press_summary">Deur die skrap-sleutel lank te druk, word hele woorde aaneenlopend geskrap</string>
     <string name="delete_swipe_summary">Doen \'n vee van die skrap sleutel om \'n groter seleksie van teks eenmaal te skrap</string>
     <string name="subtype_akkhor_bn_BD">%s (Akkhor)</string>
     <string name="incognito">Dwing incognito-modus</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -117,6 +117,8 @@
     <string name="delete_swipe">احذف بالسحب</string>
     <string name="key_borders">الحدود الرئيسة</string>
     <string name="delete_swipe_summary">أجرِ سحبًا سريعًا على مفتاح الحذف لتُحدِّد وتُزيل أجزاءً كبيرة من النص دفعةً واحدة</string>
+    <string name="delete_word_long_press">احذف الكلمات بالضغط المطول</string>
+    <string name="delete_word_long_press_summary">يؤدي الضغط المطول على مفتاح الحذف إلى حذف كلمات كاملة بشكل مستمر</string>
     <string name="show_hints">أظهِر تلميحات المفاتيح</string>
     <string name="select_input_method">"اختيار أسلوب الإدخال"</string>
     <string name="show_hints_summary">أظهِر تلميحات المفاتيح عند الضغط لفترة طويلة</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -148,6 +148,8 @@
     <string name="clipboard_history_pinned_first">Bərkidilmiş elementləri yuxarıda göstər</string>
     <string name="delete_swipe">Sürüşdürərək sil</string>
     <string name="delete_swipe_summary">Bir dəfəyə mətnin böyük hissələrini seçib silmək üçün silmə düyməsindən başlayaraq sürüşdür</string>
+    <string name="delete_word_long_press">Uzun basaraq sözü sil</string>
+    <string name="delete_word_long_press_summary">Silmə düyməsini uzun basmaq bütöv sözləri davamlı olaraen silir</string>
     <string name="backup_restore_title">Nüsxələ və bərpa et</string>
     <string name="backup_restore_message">Saxla və ya fayldan yüklə. Diqqət: bərpa mövcud verilənlərin üzərinə yazılacaq</string>
     <string name="backup_error">Nüsxələmə xətası: %s</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -125,6 +125,8 @@
     <string name="gesture_floating_preview_dynamic_summary">Преместете визуализацията по време на жест</string>
     <string name="gesture_trail_fadeout_duration">Продължителност на живота на следата на жеста</string>
     <string name="delete_swipe">Изтриване с плъзгане</string>
+    <string name="delete_word_long_press">Изтриване на дума с дълго натискане</string>
+    <string name="delete_word_long_press_summary">Дългото натискане на клавиша за изтриване изтрива цели думи непрекъснато</string>
     <string name="backup_restore_title">Архивиране и възстановяване</string>
     <string name="load_gesture_library_summary">Осигурете собствена библиотека, за да активирате писането с жестове</string>
     <string name="split_spacer_scale">Разделено разстояние</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -67,6 +67,8 @@
     <string name="clipboard_history_retention_time">ইতিহাস স্থিতির সময়কাল</string>
     <string name="delete_swipe">বিলোপ অভিস্পর্শ</string>
     <string name="delete_swipe_summary">লেখার বড়ো অংশ একসাথে সিলেক্ট করে অপসারণ করার জন্য অভিস্পর্শ করুন</string>
+    <string name="delete_word_long_press">দীর্ঘ চাপে শব্দ বিলোপ</string>
+    <string name="delete_word_long_press_summary">মুছে ফেলার বোতামটি দীর্ঘক্ষণ চেপে রাখলে একের পর এক সম্পূর্ণ শব্দ মুছে যায়</string>
     <string name="secondary_locale">বহুভাষী টাইপিং</string>
     <string name="load_gesture_library">অঙ্গুলিহেলন টাইপিং লাইব্রেরি অধিযোগ</string>
     <string name="load_gesture_library_summary">অঙ্গুলিহেলনের মাধ্যমে টাইপিং সক্রিয় করার জন্য স্থানীয় লাইব্রেরি সরবরাহ</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -96,6 +96,8 @@
     <string name="enable_clipboard_history_summary">Si es desactiva, la tecla del porta-retalls enganxarà el contingut del porta-retalls si n\'hi ha</string>
     <string name="clipboard_history_retention_time">Temps de manteniment a l\'historial</string>
     <string name="delete_swipe_summary">Llisqueu damunt de la tecla d\'esborrar per seleccionar i treure grans parts de text d\'un sol cop</string>
+    <string name="delete_word_long_press">Esborra la paraula amb una pulsació llarga</string>
+    <string name="delete_word_long_press_summary">Mantenir premuda la tecla d\'esborrar elimina paraules senceres de manera contínua</string>
     <string name="incognito">Força el mode d\'incògnit</string>
     <string name="abbreviation_unit_minutes">%s min</string>
     <string name="spell_checker_service_name">Corrector ortogràfic de l\'HeliBoard</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -110,6 +110,8 @@
     <string name="settings_category_input">Vstup</string>
     <string name="settings_category_additional_keys">Dodatečné klávesy</string>
     <string name="delete_swipe">Mazat posunutím</string>
+    <string name="delete_word_long_press">Mazat slova dlouhým stiskem</string>
+    <string name="delete_word_long_press_summary">Dlouhým stisknutím klávesy pro mazání budete nepřetržitě mazat celá slova</string>
     <string name="number_row_summary">Vždy aktivní číselný řádek</string>
     <string name="show_hints">Nápověda kláves</string>
     <string name="show_hints_summary">Nápověda při dlouhém stisku</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -121,6 +121,8 @@
     <string name="settings_category_miscellaneous">Diverse</string>
     <string name="delete_swipe">Swipe-sletning</string>
     <string name="delete_swipe_summary">Udfør et swipe fra slet-tasten for at vælge og fjerne større dele af teksten på én gang</string>
+    <string name="delete_word_long_press">Slet ord ved langt tryk</string>
+    <string name="delete_word_long_press_summary">Hvis du holder slet-tasten nede, slettes hele ord kontinuerligt</string>
     <string name="incognito">Gennemtving inkognitotilstand</string>
     <string name="prefs_force_incognito_mode_summary">Deaktiver indlæring af nye ord</string>
     <string name="more_keys_strip_description">Flere taster</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -107,6 +107,8 @@
     <string name="settings_category_miscellaneous">Sonstiges</string>
     <string name="enable_clipboard_history">Zwischenablage-Verlauf aktivieren</string>
     <string name="delete_swipe_summary">Wische über die Löschen-Taste, um mehr Text auf einmal auszuwählen und zu löschen</string>
+    <string name="delete_word_long_press">Wort löschen durch langes Drücken</string>
+    <string name="delete_word_long_press_summary">Durch langes Drücken der Löschen-Taste werden ganze Wörter kontinuierlich gelöscht</string>
     <string name="clipboard_history_retention_time">Speicherdauer des Zwischenablage-Verlaufs</string>
     <string name="delete_swipe">Löschen durch Wischen</string>
     <string name="prefs_force_incognito_mode_summary">Deaktiviert das Lernen von neuen Wörtern</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -100,6 +100,8 @@
     <string name="spell_checker_service_name">Ορθογραφικός Έλεγχος HeliBoard</string>
     <string name="delete_swipe">Διαγραφή ολίσθησης</string>
     <string name="delete_swipe_summary">Πραγματοποιήστε μια σάρωση από το πλήκτρο διαγραφής για να επιλέξετε και να αφαιρέσετε μεγαλύτερα τμήματα κειμένου ταυτόχρονα</string>
+    <string name="delete_word_long_press">Διαγραφή λέξης με παρατεταμένο πάτημα</string>
+    <string name="delete_word_long_press_summary">Το παρατεταμένο πάτημα του πλήκτρου διαγραφής διαγράφει ολόκληρες λέξεις συνεχόμενα</string>
     <string name="incognito">Αναγκαστική λειτουργία ανώνυμης περιήγησης</string>
     <string name="show_emoji_key">Πλήκτρο emoji</string>
     <string name="settings_category_additional_keys">Πρόσθετα κλειδιά</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -96,6 +96,8 @@
     <string name="android_spell_checker_settings">HeliBoard Spell Checker Settings</string>
     <string name="number_row_summary">Always show number row</string>
     <string name="delete_swipe">Delete swipe</string>
+    <string name="delete_word_long_press">Delete word on long press</string>
+    <string name="delete_word_long_press_summary">Long pressing delete key deletes whole words continuously</string>
     <string name="prefs_force_incognito_mode_summary">Disable learning of new words</string>
     <string name="show_emoji_key">Emoji key</string>
     <string name="incognito">Force incognito mode</string>

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -104,6 +104,8 @@
     <string name="settings_no_limit">Sin límite</string>
     <string name="settings_category_suggestions">Sugerencias</string>
     <string name="delete_swipe">Borrar deslizando</string>
+    <string name="delete_word_long_press">Borrar palabra por pulsación larga</string>
+    <string name="delete_word_long_press_summary">Mantener pulsada la tecla de borrar elimina palabras completas de forma continua</string>
     <string name="autospace_after_punctuation">Espacio después del punto</string>
     <string name="incognito">Forzar modo incógnito</string>
     <string name="number_row_summary">Mostrar siempre la fila de números</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -101,6 +101,8 @@
     <string name="prefs_keyboard_height_scale">Escala de altura del teclado</string>
     <string name="delete_swipe">Borrar deslizando</string>
     <string name="delete_swipe_summary">Deslice el dedo por la tecla Borrar para seleccionar y eliminar porciones más grandes de texto de una vez</string>
+    <string name="delete_word_long_press">Borrar palabra por pulsación larga</string>
+    <string name="delete_word_long_press_summary">Mantener pulsada la tecla de borrar elimina palabras completas de forma continua</string>
     <string name="prefs_force_incognito_mode_summary">Desactiva el aprendizaje de nuevas palabras</string>
     <string name="incognito">Forzar el modo incógnito</string>
     <string name="more_keys_strip_description">Más teclas</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -182,6 +182,8 @@
     <string name="left" tools:keep="@string/left">Vasakule</string>
     <string name="load_gesture_library_summary">Kasuta oma teeki, mis kirjeldab trükkimisel kasutatavaid viipamisi</string>
     <string name="delete_swipe_summary">Alustades viipamist kustutamise nupust luba suurema kustutatava teksti valimine</string>
+    <string name="delete_word_long_press">Kustuta sõna pika vajutusega</string>
+    <string name="delete_word_long_press_summary">Kustutamise nupu pikk vajutamine kustutab järjest terveid sõnu</string>
     <string name="popup_order">Vali hüpikakna klahvide järjekord</string>
     <string name="show_hints_summary">Näita klahvide pika vajutuse vihjeid</string>
     <string name="delete_swipe">Kustutamine viipamisega</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -122,6 +122,8 @@
     <string name="show_emoji_key">Emoji tekla</string>
     <string name="delete_swipe">Desgaitu irristatzea</string>
     <string name="delete_swipe_summary">Ezabatu teklatik hatza irristatu, testuaren zati handiagoak hautatzeko eta ezabatzeko</string>
+    <string name="delete_word_long_press">Ezabatu hitza luze sakatuta</string>
+    <string name="delete_word_long_press_summary">Ezabatzeko tekla luze sakatzean hitz osoak ezabatzen dira etengabe</string>
     <string name="autospace_after_punctuation_summary">Sartu automatikoki zuriunea puntuazioen ondoren hitz berri bat idaztean</string>
     <string name="prefs_long_press_keyboard_to_change_lang">Aldatu idazketa-metodoa zuriune teklarekin</string>
     <string name="prefs_keyboard_height_scale">Teklatuaren altuera eskala</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -116,6 +116,8 @@
     <string name="prefs_long_press_keyboard_to_change_lang">تغییر روش ورودی با کلید فاصله</string>
     <string name="delete_swipe">حذف با کشیدن (Swipe)</string>
     <string name="delete_swipe_summary">کشیدن انگشت از سمت کلید حذف برای انتخاب و پاک کردن بخش‌های بزرگ‌تری از متن به صورت یکجا</string>
+    <string name="delete_word_long_press">حذف کلمه با فشار طولانی</string>
+    <string name="delete_word_long_press_summary">فشار دادن طولانی کلید حذف، کلمات کامل را به طور مداوم پاک می‌کند</string>
     <string name="incognito">اجبار به حالت ناشناس (Incognito)</string>
     <string name="prefs_force_incognito_mode_summary">غیرفعال کردن یادگیری کلمات جدید</string>
     <string name="autospace_after_punctuation">فاصله خودکار پس از علائم نگارشی</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -269,6 +269,8 @@
     <string name="auto_correction_confidence">Automaattisen korjauksen luottamus</string>
     <string name="show_hints_summary">Näytä pitkän painalluksen vinkit</string>
     <string name="delete_swipe_summary">Pyyhkäise poistonäppäimestä valitaksesi ja poistaaksesi suurempia tekstiosia kerralla</string>
+    <string name="delete_word_long_press">Poista sana pitkällä painalluksella</string>
+    <string name="delete_word_long_press_summary">Poistonäppäimen pitkä painaminen poistaa kokonaisia sanoja jatkuvasti</string>
     <string name="show_popup_keys_more">Lisää yleiset muunnelmat</string>
     <string name="popup_keys_language_priority" tools:keep="@string/popup_keys_language_priority">Kieli (ensisijaisuus)</string>
     <string name="prefs_always_show_suggestions_summary">Ohita muiden sovellusten pyyntö poistaa ehdotukset käytöstä (saattaa aiheuttaa ongelmia)</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -71,6 +71,8 @@
     <string name="gesture_space_aware_summary">Maglagay ng mga space sa pag-gesture sa pamamagitan ng pag-glide sa space key</string>
     <string name="gesture_fast_typing_cooldown">Cooldown ng mabilis na pag-type</string>
     <string name="delete_swipe">Delete na pag-swipe</string>
+    <string name="delete_word_long_press">Burahin ang salita sa matagal na pagpindot</string>
+    <string name="delete_word_long_press_summary">Ang matagal na pagpindot sa delete key ay patuloy na nagbubura ng mga buong salita</string>
     <string name="gesture_floating_preview_dynamic_summary">Ilipat ang preview habang may gesture</string>
     <string name="gesture_fast_typing_cooldown_instant">Palaging simulan agad</string>
     <string name="gesture_trail_fadeout_duration">Tagal ng gesture trail</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -139,6 +139,8 @@ Nouveau dictionnaire:
     <string name="number_row">Ligne de chiffres</string>
     <string name="delete_swipe">Balayage sur la touche Effacer</string>
     <string name="delete_swipe_summary">Glissez sur la touche de suppression pour supprimer des parties de texte en une seule fois</string>
+    <string name="delete_word_long_press">Effacer le mot par appui long</string>
+    <string name="delete_word_long_press_summary">Un appui long sur la touche Effacer supprime des mots entiers en continu</string>
     <string name="backup_restore_title">Sauvegarde et restauration</string>
     <string name="backup_restore_message">Sauvegarde ou chargement à partir d\'un fichier. Attention : la restauration écrasera les données existantes.</string>
     <string name="backup_error">Erreur lors de la sauvegarde : %s</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -177,6 +177,8 @@
     <string name="clipboard_history_retention_time">Período de retención do historial</string>
     <string name="delete_swipe">Borrar ao desprazar</string>
     <string name="delete_swipe_summary">Fai un xesto de desprazamento desde a tecla eliminar e elimina anacos grandes de texto dunha pasada</string>
+    <string name="delete_word_long_press">Borrar palabra por pulsación longa</string>
+    <string name="delete_word_long_press_summary">Manter premida a tecla de borrar elimina palabras completas de forma continua</string>
     <string name="backup_restore_title">Copia de apoio e restablecer</string>
     <string name="backup_restore_message">Garda ou restablecer desde un ficheiro. Aviso: o restablecemento sobrescribe os datos</string>
     <string name="backup_error">Fallo na copia: %s</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -110,6 +110,8 @@
     <string name="clipboard_history_retention_time">Vrijeme zadržavanja povijesti</string>
     <string name="delete_swipe">Izbriši povlačenjem</string>
     <string name="delete_swipe_summary">Povuci prstom od tipke za brisanje, za biranje i uklanjanje većih dijelova teksta</string>
+    <string name="delete_word_long_press">Izbriši riječ dugim pritiskom</string>
+    <string name="delete_word_long_press_summary">Dugi pritisak na tipku za brisanje kontinuirano briše cijele riječi</string>
     <string name="prefs_force_incognito_mode_summary">Onemogući učenje novih riječi</string>
     <string name="autospace_after_punctuation">Automatski dodaj razmak nakon interpunkcije</string>
     <string name="autospace_after_punctuation_summary">Automatski dodaj razmak nakon interpunkcije kad pišeš novu riječ</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -103,6 +103,8 @@
     <string name="android_spell_checker_settings">HeliBoard helyesírás-ellenőrző beállításai</string>
     <string name="settings_category_additional_keys">További billentyűk</string>
     <string name="delete_swipe_summary">A törlés billentyűről való csúsztatással nagyobb szövegrészleteket jelölhet ki és távolíthat el</string>
+    <string name="delete_word_long_press">Szó törlése hosszan nyomva tartással</string>
+    <string name="delete_word_long_press_summary">A törlés billentyű hosszan nyomva tartásával folyamatosan törölhet teljes szavakat</string>
     <string name="enable_clipboard_history_summary">Ha le van tiltva, a vágólapbillentyű beilleszti a vágólap tartalmát, ha van</string>
     <string name="clipboard_history_retention_time">Előzmények megőrzésének ideje</string>
     <string name="prefs_keyboard_height_scale">Billentyűzet magassága</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -94,6 +94,8 @@
     <string name="prefs_keyboard_height_scale">Skala tinggi keyboard</string>
     <string name="delete_swipe">Gestur hapus</string>
     <string name="delete_swipe_summary">Sentuh dan geser ke kiri pada tombol hapus untuk menghapus beberapa huruf/kata sekaligus</string>
+    <string name="delete_word_long_press">Hapus kata dengan tekan lama</string>
+    <string name="delete_word_long_press_summary">Menekan lama tombol hapus akan menghapus seluruh kata secara terus-menerus</string>
     <string name="settings_category_clipboard_history">Riwayat papan klip</string>
     <string name="settings_no_limit">Tidak ada batas</string>
     <string name="enable_clipboard_history">Aktifkan riwayat papan klip</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -200,6 +200,8 @@
     <string name="no_dictionary_dont_show_again_button">Ekki birta þetta aftur</string>
     <string name="key_code">Lykilkóði</string>
     <string name="delete_swipe">Stroka til að eyða</string>
+    <string name="delete_word_long_press">Eyða orði með því að ýta lengi</string>
+    <string name="delete_word_long_press_summary">Með því að halda eyðingarlyklinum inni eyðast heil orð í röð</string>
     <string name="save_log">Vista atvikaskrá</string>
     <string name="prefs_space_bar_text">Sérsniðinn texti á bilslá</string>
     <string name="auto_show_toolbar">Birta verkfærastiku sjálfvirkt</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -106,6 +106,8 @@
     <string name="number_row">Riga dei numeri</string>
     <string name="delete_swipe">Scorri per cancellare</string>
     <string name="delete_swipe_summary">Scorri indietro partendo da \'Backspace\' per rimuovere più caratteri o parole in una sola volta</string>
+    <string name="delete_word_long_press">Cancella parola con pressione prolungata</string>
+    <string name="delete_word_long_press_summary">Tenendo premuto il tasto di cancellazione si eliminano intere parole continuamente</string>
     <string name="incognito">Modalità incognito</string>
     <string name="show_emoji_key">Tasto emoji</string>
     <string name="number_row_summary">Mostra sempre la riga dei numeri</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -143,6 +143,8 @@
     <string name="enable_clipboard_history">クリップボード履歴をイネーブルする</string>
     <string name="clipboard_history_retention_time">履歴を保つ時間</string>
     <string name="delete_swipe">デリートスワイプ</string>
+    <string name="delete_word_long_press">長押しで単語を削除</string>
+    <string name="delete_word_long_press_summary">削除キーを長押しすると、単語単位で連続して削除します</string>
     <string name="load_gesture_library_button_delete">ライブラリーをデリートする</string>
     <string name="autospace_before_gesture_typing">ゲスチャー入力の前に自動にスペースする</string>
     <string name="autospace_after_gesture_typing">ゲスチャー入力の後で自動にスペースする</string>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -108,6 +108,8 @@
     <string name="incognito">ნაძალადევი ინკოგნიტოს რეჟიმი</string>
     <string name="prefs_force_incognito_mode_summary">ახალი სიტყვების სწავლის გამორთვა</string>
     <string name="delete_swipe_summary">ტექსტის დიდი პორციების მოსანიშნად და წასაშლელად წაშლის ღილაკს გაუსვით</string>
+    <string name="delete_word_long_press">სიტყვის წაშლა ხანგრძლივი დაჭერით</string>
+    <string name="delete_word_long_press_summary">წაშლის ღილაკზე ხანგრძლივი დაჭერა მთლიან სიტყვებს უწყვეტად შლის</string>
     <string name="prefs_long_press_keyboard_to_change_lang">შეყვანის მეთოდის გამოტოვების ღილაკით შეცვლა</string>
     <string name="prefs_long_press_keyboard_to_change_lang_summary">გამოტოვების ღილაკზე დიდხანს დაწოლა შეყვანის მეთოდის მენიუს გაჩვენებთ</string>
     <string name="show_hints">ღილაკის მინიშნებების ჩვენება</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -104,6 +104,8 @@
     <string name="abbreviation_unit_minutes">%s분.</string>
     <string name="enable_clipboard_history">클립보드 기록 활성화</string>
     <string name="delete_swipe">스와이프 삭제</string>
+    <string name="delete_word_long_press">길게 눌러 단어 삭제</string>
+    <string name="delete_word_long_press_summary">삭제 키를 길게 누르면 전체 단어가 연속으로 삭제됩니다</string>
     <string name="show_emoji_key">이모지 키</string>
     <string name="settings_category_input">입력</string>
     <string name="settings_category_additional_keys">추카 키</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -163,6 +163,8 @@
     <string name="clipboard_history_pinned_first">Prisegtus įrašus laikyti viršuje</string>
     <string name="delete_swipe">Trynimas perbraukiant</string>
     <string name="delete_swipe_summary">Norėdami pašalinti daugiau teksto, naudokite perbraukimą nuo šalinimo klavišo iki pasirinkimo</string>
+    <string name="delete_word_long_press">Trinti žodį ilgu paspaudimu</string>
+    <string name="delete_word_long_press_summary">Ilgai spaudžiant trynimo klavišą, ištisi žodžiai trinami nepertraukiamai</string>
     <string name="backup_restore_title">Išsaugoti ir atkurti</string>
     <string name="backup_restore_message">Išsaugoti ir įkelti iš failo. Įspėjimas: atkuriant bus pašalinti esami duomenys</string>
     <string name="backup_error">Atkūrimo klaida: %s</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -101,6 +101,8 @@
     <string name="show_hints">കീ സൂചനകൾ കാണിക്കുക</string>
     <string name="android_spell_checker_settings">ഓപ്പൺബോർഡ് സ്പെൽ ചെക്കർ ക്രമീകരണങ്ങൾ</string>
     <string name="delete_swipe">ഡിലീറ്റ് സ്വൈപ്പ്</string>
+    <string name="delete_word_long_press">ലോങ്ങ് പ്രസ്സ് ചെയ്ത് വാക്ക് ഡിലീറ്റ് ചെയ്യുക</string>
+    <string name="delete_word_long_press_summary">ഡിലീറ്റ് കീ ലോങ്ങ് പ്രസ്സ് ചെയ്യുന്നത് തുടർച്ചയായി മുഴുവൻ വാക്കുകളും മായ്ക്കുന്നു</string>
     <string name="show_emoji_key">ഇമോജി കീ</string>
     <string name="prefs_force_incognito_mode_summary">പുതിയ വാക്കുകൾ പഠിക്കുന്നത് അപ്രാപ്തമാക്കുക</string>
     <string name="settings_category_suggestions">നിർദ്ദേശങ്ങൾ</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -130,6 +130,8 @@
     <string name="use_apps_dict_summary">Guna nama aplikasi dipasang untuk cadangan dan pembetulan</string>
     <string name="disable_personalized_dicts_message">Amaran: Menyahdayakan tetapan ini akan mengosongkan data yang telah dipelajari</string>
     <string name="delete_swipe_summary">Sapu daripada kekunci padam untuk memilih dan membuang teks yang lebih banyak sekaligus</string>
+    <string name="delete_word_long_press">Padam perkataan dengan tekan lama</string>
+    <string name="delete_word_long_press_summary">Menekan lama kekunci padam akan membuang keseluruhan perkataan secara berterusan</string>
     <string name="backup_restore_title">Sandarkan dan pulihkan</string>
     <string name="backup_restore_message">Simpan atau muat daripada fail. Amaran: pemulihan akan menimpa data sedia ada</string>
     <string name="backup_error">Ralat sandaran: %s</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -158,6 +158,8 @@
     <string name="clipboard_history_pinned_first">အထူးမှတ်သားထားသော အကြောင်းအရာများကို ထိပ်ဆုံးတွင်ပြရန်</string>
     <string name="delete_swipe">ပွတ်ဆွဲ၍ ဖျက်ရန်</string>
     <string name="delete_swipe_summary">နောက်ကြောင်းပြန်ခလုပ်ကိုဖိ၍ ဘယ်ဘက်သို့ပွတ်ဆွဲခြင်းဖြင့် ရိုက်နှိပ်ထားပြီးသော စာများအားလုံးကို သိမ်းကျုံးဖျက်ပါ</string>
+    <string name="delete_word_long_press">ကြာရှည်နှိပ်၍ စာလုံးဖျက်ရန်</string>
+    <string name="delete_word_long_press_summary">ဖျက်ရန်ခလုတ်ကို ကြာရှည်နှိပ်ထားပါက စာလုံးအပြည့်အစုံများကို အစဉ်တစိုက် ဖျက်ပေးပါမည်</string>
     <string name="backup_restore_title">အရန်သိမ်းဆည်းခြင်းနှင့် ပြန်လည်ထည့်သွင်းခြင်း</string>
     <string name="backup_restore_message">ဖိုင်စနစ်တွင် သိမ်းဆည်းခြင်းနှင့် ၎င်းစနစ်မှ ပြန်လည်ထည့်သွင်းခြင်း လုပ်ငန်းများဆောင်ရွက်ရန်။ သတိ - ထည့်သွင်းခြင်းလုပ်ငန်းကိုဆောင်ရွက်ပါက လက်ရှိရှိနေသော အချက်အလက်များအားလုံးကို ပယ်ဖျက်လိမ့်မည်</string>
     <string name="backup_error">%s အရန်သိမ်းဆည်းမှုလုပ်ငန်းမအောင်မြင်ပါ</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -99,6 +99,8 @@
     <string name="spell_checker_service_name">HeliBoard-stavekontroll</string>
     <string name="android_spell_checker_settings">Innstillinger for HeliBoard-stavekontroll</string>
     <string name="delete_swipe">Sveip for å slette</string>
+    <string name="delete_word_long_press">Slett ord med langt trykk</string>
+    <string name="delete_word_long_press_summary">Ved å holde slettetasten inne slettes hele ord kontinuerlig</string>
     <string name="show_emoji_key">Emoji-tast</string>
     <string name="delete_swipe_summary">Utfør en dragning fra Delete-tasten for å velge og fjerne større deler av tekst samtidig</string>
     <string name="settings_category_additional_keys">Ytterligere taster</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -101,6 +101,8 @@
     <string name="settings_no_limit">Geen limiet</string>
     <string name="clipboard_history_retention_time">Bewaartijd van de geschiedenis</string>
     <string name="delete_swipe">Verwijderen met veegbeweging</string>
+    <string name="delete_word_long_press">Woord verwijderen door lang indrukken</string>
+    <string name="delete_word_long_press_summary">De herhaaltoets of verwijdertoets lang ingedrukt houden verwijdert continu hele woorden</string>
     <string name="enable_clipboard_history">Klembordgeschiedenis inschakelen</string>
     <string name="more_keys_strip_description">Meer toetsen</string>
     <string name="number_row_summary">Cijferregel altijd weergeven</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -110,6 +110,8 @@
     <string name="prefs_long_press_keyboard_to_change_lang">Zmień metodę wprowadzania za pomocą spacji</string>
     <string name="show_hints_summary">Pokazuj wskazówki dotyczące długiego naciśnięcia przycisku</string>
     <string name="delete_swipe_summary">Przesuń palcem od klawisza usuwania, aby zaznaczyć i usunąć większe fragmenty tekstu za jednym razem</string>
+    <string name="delete_word_long_press">Usuń słowo przez długie naciśnięcie</string>
+    <string name="delete_word_long_press_summary">Długie naciśnięcie klawisza usuwania powoduje ciągłe usuwanie całych słów</string>
     <string name="enable_clipboard_history_summary">Po wyłączeniu, klawisz schowka będzie wklejał zawartość schowka, jeśli taka istnieje</string>
     <string name="delete_swipe">Gest usunięcia</string>
     <string name="prefs_long_press_keyboard_to_change_lang_summary">Długie naciśnięcie klawisza spacji spowoduje wyświetlenie menu wyboru metody wprowadzania tekstu</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -39,6 +39,8 @@
     <string name="enable_clipboard_history">Ativar histórico da área de transferência</string>
     <string name="delete_swipe_summary">Deslize da tecla delete para selecionar e remover partes de texto maiores de uma vez só</string>
     <string name="delete_swipe">Deslizar para apagar</string>
+    <string name="delete_word_long_press">Apagar palavra ao pressionar longamente</string>
+    <string name="delete_word_long_press_summary">Pressionar longamente a tecla delete remove palavras inteiras continuamente</string>
     <string name="incognito">Forçar modo privativo</string>
     <string name="prefs_force_incognito_mode_summary">Desativar aprendizagem de novas palavras</string>
     <string name="more_keys_strip_description">Mais teclas</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -95,6 +95,8 @@
     <string name="show_hints_summary">Mostrar dicas com toque longo</string>
     <string name="delete_swipe">Deslize para eliminar</string>
     <string name="delete_swipe_summary">Pode deslizar desde a tecla \'Apagar\' para selecionar e remover grandes porções de texto de uma vez</string>
+    <string name="delete_word_long_press">Eliminar palavra ao premir longamente</string>
+    <string name="delete_word_long_press_summary">Premir longamente a tecla de apagar elimina palavras inteiras continuamente</string>
     <string name="show_emoji_key">Tecla de emoji</string>
     <string name="incognito">Impor modo incógnito</string>
     <string name="day_night_mode">Modo diurno/noturno automático</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -107,6 +107,8 @@
     <string name="delete_swipe">Deslize para eliminar</string>
     <string name="more_keys_strip_description">Mais teclas</string>
     <string name="delete_swipe_summary">Pode deslizar desde a tecla Eliminar para selecionar e remover grandes porções de texto de uma vez</string>
+    <string name="delete_word_long_press">Eliminar palavra ao premir longamente</string>
+    <string name="delete_word_long_press_summary">Premir longamente a tecla de apagar elimina palavras inteiras continuamente</string>
     <string name="prefs_keyboard_height_scale">Altura do teclado</string>
     <string name="prefs_long_press_keyboard_to_change_lang_summary">Toque longo na tecla Espaço abre menu de seleção do método de introdução</string>
     <string name="show_hints">Mostrar dicas de teclas</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -137,6 +137,8 @@
     <string name="button_backup">Copie de rezervă</string>
     <string name="delete_swipe">Ștergere prin glisare</string>
     <string name="delete_swipe_summary">Efectuează o glisare de la tasta de ștergere pentru a selecta și a elimina simultan porțiuni mai mari de text</string>
+    <string name="delete_word_long_press">Ștergere cuvânt prin apăsare lungă</string>
+    <string name="delete_word_long_press_summary">Apăsarea lungă a tastei de ștergere elimină cuvinte întregi în mod continuu</string>
     <string name="backup_restore_title">Copie de rezervă și restaurare</string>
     <string name="popup_order">Selectează ordinea tastelor pop-up</string>
     <string name="number_row">Rând de numere</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -104,6 +104,8 @@
     <string name="url_detection_summary">Попытаться обнаружить URL-адреса и схожие конструкции как единое целое</string>
     <string name="delete_swipe">Удаление смахиванием</string>
     <string name="delete_swipe_summary">Смахните от клавиши удаления, чтобы выделить и сразу удалить большие фрагменты текста</string>
+    <string name="delete_word_long_press">Удаление слова удержанием</string>
+    <string name="delete_word_long_press_summary">Длительное нажатие клавиши удаления непрерывно стирает целые слова</string>
     <string name="backup_restore_title">Резервное копирование и восстановление</string>
     <string name="backup_restore_message">Сохранить или загрузить из файла. Внимание: восстановление перезапишет существующие данные</string>
     <string name="backup_error">Ошибка резервного копирования: %s</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -94,6 +94,8 @@
     <string name="select_input_method">"Izberite način vnosa"</string>
     <string name="auto_correction_confidence">Interval zaupanja samodejnih popravkov</string>
     <string name="delete_swipe_summary">Podrsaj z vračalke, da izbereš in izbrišeš večje dele besedila naenkrat</string>
+    <string name="delete_word_long_press">Izbris besede z dolgim pritiskom</string>
+    <string name="delete_word_long_press_summary">Z dolgim pritiskom na vračalko neprekinjeno brišete celotne besede</string>
     <string name="incognito">Vsiljen prikriti način</string>
     <string name="number_row_summary">Vedno pokaži vrstico s številkami</string>
     <string name="show_hints">Prikaži namige tipk</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -117,6 +117,8 @@
     <string name="clipboard_history_retention_time">Lagringstid för historik</string>
     <string name="delete_swipe">Backstegssvepning</string>
     <string name="delete_swipe_summary">Gör en svepning från backstegstangenten för att markera och ta bort större mängder text på en gång</string>
+    <string name="delete_word_long_press">Ta bort ord med långtryck</string>
+    <string name="delete_word_long_press_summary">Genom att hålla backstegsknappen nedtryckt raderas hela ord kontinuerligt</string>
     <string name="autospace_after_punctuation_summary">Infoga automatiskt mellanslag efter skiljetecken när ett nytt ord skrivs</string>
     <string name="autospace_after_punctuation">Automatiskt mellanslag efter skiljetecken</string>
     <string name="more_keys_strip_description">Fler tangenter</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -161,6 +161,8 @@
     <string name="clipboard_history_pinned_first">பின் செய்யப்பட்ட பொருட்களை மேலே காட்டு</string>
     <string name="delete_swipe">ச்வைப் செய்வதை நீக்கு</string>
     <string name="delete_swipe_summary">ஒரே நேரத்தில் உரையின் பெரிய பகுதிகளைத் தேர்ந்தெடுத்து அகற்ற, நீக்கு விசையிலிருந்து ச்வைப் செய்யவும்</string>
+    <string name="delete_word_long_press">நெடுநேரம் அழுத்தி வார்த்தையை நீக்கு</string>
+    <string name="delete_word_long_press_summary">நீக்கு பொத்தானை நெடுநேரம் அழுத்திப் பிடிப்பதன் மூலம் முழு வார்த்தைகளையும் தொடர்ச்சியாக நீக்கலாம்</string>
     <string name="backup_restore_title">காப்பு மற்றும் மீட்டமை</string>
     <string name="backup_restore_message">கோப்பிலிருந்து சேமிக்கவும் அல்லது ஏற்றவும். எச்சரிக்கை: மீட்டெடுப்பு ஏற்கனவே உள்ள தரவை மேலெழுதும்</string>
     <string name="backup_error">காப்புப் பிழை: %s</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -103,6 +103,8 @@
     <string name="android_spell_checker_settings">HeliBoard yazım denetleyicisi ayarları</string>
     <string name="prefs_keyboard_height_scale">Klavye yükseklik ölçeği</string>
     <string name="delete_swipe">Kadırarak silme</string>
+    <string name="delete_word_long_press">Uzun basarak kelime silme</string>
+    <string name="delete_word_long_press_summary">Silme tuşuna uzun basıldığında tüm kelimeler kesintisiz olarak silinir</string>
     <string name="key_borders">Tuş kenarlıkları</string>
     <string name="day_night_mode">Otomatik gündüz/gece modu</string>
     <string name="spell_checker_service_name">HeliBoard yazım denetleyicisi</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -150,6 +150,8 @@
     <string name="prefs_narrow_key_gaps">Збільшені клавіші</string>
     <string name="delete_swipe">Видаляти ковзанням</string>
     <string name="delete_swipe_summary">Проведіть пальцем по клавіші видалення, щоб виділити і вилучити більші фрагменти тексту за раз</string>
+    <string name="delete_word_long_press">Видалення слова довгим натисканням</string>
+    <string name="delete_word_long_press_summary">Тривале утримання клавіші видалення безперервно стирає цілі слова</string>
     <string name="url_detection_title">Виявлення URL-адреси</string>
     <string name="url_detection_summary">Спробувати виявити URL-адреси та подібні до них рядки, як одне слово</string>
     <string name="backup_restore_title">Резервне копіювання та відновлення</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -100,6 +100,8 @@
     <string name="enable_clipboard_history_summary">Agar o\'chirilgan bo\'lsa, vaqtinchalik bufer tugmasi mavjud bo\'lsa, almashish buferidagi kontentni joylashtiradi</string>
     <string name="clipboard_history_retention_time">Tarixni saqlash vaqti</string>
     <string name="delete_swipe_summary">Matnning katta qismini birdaniga tanlash va o‘chirib tashlash uchun oʻchirish tugmasidan suring</string>
+    <string name="delete_word_long_press">Uzoq bosib so‘zni o‘chirish</string>
+    <string name="delete_word_long_press_summary">Oʻchirish tugmasini uzoq bosib turish butun so‘zlarni ketma-ket o‘chirib tashlaydi</string>
     <string name="key_borders">Tugma chegaralari</string>
     <string name="day_night_mode">Avtomatik kunduz/tun rejimi</string>
     <string name="day_night_mode_summary">Tashqi ko\'rinish tizim sozlamalariga binoan</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -100,6 +100,8 @@
     <string name="enable_clipboard_history">启用剪贴板历史</string>
     <string name="clipboard_history_retention_time">历史保留时间</string>
     <string name="delete_swipe_summary">从删除键滑动，一次选择并删除较大的文本部分</string>
+    <string name="delete_word_long_press">长按删除单词</string>
+    <string name="delete_word_long_press_summary">长按删除键可连续删除完整单词</string>
     <string name="incognito">强制隐身模式</string>
     <string name="show_hints_summary">显示长按提示</string>
     <string name="number_row_summary">始终显示数字行</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -220,6 +220,10 @@
     <string name="delete_swipe">Delete swipe</string>
     <!-- Description for "delete_swipe" option. -->
     <string name="delete_swipe_summary">Perform a swipe from the delete key to select and remove bigger portions of text at once</string>
+    <!-- Preferences item for enabling whole word deletion -->
+    <string name="delete_word_long_press">Delete word on long press</string>
+    <!-- Description for "delete_word_long_press" option. -->
+    <string name="delete_word_long_press_summary">Long pressing delete key deletes whole words continuously</string>
     <!-- Preferences item and dialog title for backup and restore -->
     <string name="backup_restore_title">Backup and restore</string>
     <!-- Message for backup and restore dialog -->


### PR DESCRIPTION
Added a new _**Delete Whole Word**_ feature. You can now delete whole words by long pressing the backspace key. Speed of erasing depends on the key long press delay defined by user.
Also, added a toggle **_(Delete Word on long press)_** for the feature in **Advanced** settings page.

<img width="1662" height="840" alt="2026-06-14 01 02 54" src="https://github.com/user-attachments/assets/f6c1dbbe-5c9f-4f10-b64d-c04112409bab" />

Apk can be tested here:
[Release](https://github.com/MohamedWw2/HeliBoard/releases/tag/v3.9)


https://github.com/user-attachments/assets/7ce56594-1207-4348-a8d6-7ec17de45985

