### PR TITLE
Add Toki Pona (tok) as a built-in language subtype

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/common/LocaleUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/common/LocaleUtils.kt
@@ -190,6 +190,7 @@ object LocaleUtils {
             "hi-Latn" -> R.string.subtype_hi_Latn
             "sr-Latn" -> R.string.subtype_sr_Latn
             "mns" -> R.string.subtype_mns
+            "tok" -> R.string.subtype_tok
             "xdq" -> R.string.subtype_xdq
             "dru" -> R.string.subtype_dru
             "st" -> R.string.subtype_st

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -450,6 +450,8 @@
     <string name="subtype_dru">Dargwa (Urakhi)</string>
     <!-- Name for Eastern Mari (https://en.wikipedia.org/wiki/Meadow_Mari_language) keyboard subtype -->
     <string name="subtype_mhr">Mari (Eastern)</string>
+    <!-- Name for Toki Pona (https://en.wikipedia.org/wiki/Toki_Pona) keyboard subtype -->
+    <string name="subtype_tok">Toki Pona</string>
     <!-- Description for a generic language / layout combination. %1$s is the language, %2$s is the layout -->
     <string name="subtype_with_layout_generic">%1$s (%2$s)</string>
     <!-- Description for "LANGUAGE_NAME" (Extended) keyboard subtype -->

--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -118,6 +118,7 @@
     ta_SG: Tamil (Singapore)/tamil
     te_IN: Telugu (India)/telugu
     th: Thai/thai
+    tok: Toki Pona/qwerty
     tl: Tagalog/qwerty+
     tr: Turkish/turkish
     ur_PK: Urdu Pakistan
@@ -1227,6 +1228,15 @@
         android:imeSubtypeMode="keyboard"
         android:imeSubtypeExtraValue="KeyboardLayoutSet=MAIN:thai,NoShiftProximityCorrection,EmojiCapable"
         android:isAsciiCapable="false"
+    />
+    <subtype android:icon="@drawable/ic_ime_switcher"
+        android:label="@string/subtype_generic"
+        android:subtypeId="0x67e4505d"
+        android:imeSubtypeLocale="tok"
+        android:languageTag="tok"
+        android:imeSubtypeMode="keyboard"
+        android:imeSubtypeExtraValue="AsciiCapable,SupportTouchPositionCorrection,EmojiCapable"
+        android:isAsciiCapable="true"
     />
     <subtype android:icon="@drawable/ic_ime_switcher"
         android:label="@string/subtype_generic"


### PR DESCRIPTION
Picks up your invitation in discussion [#2502](https://github.com/HeliBorg/HeliBoard/discussions/2502) (cc @IamBugs who originally asked for this).

## What this adds

Toki Pona has 14 letters (a e i j k l m n o p s t u w) — all ASCII — so a qwerty layout covers it without a custom layout file. This matches the Piedmontese / Tagalog / Swahili pattern of `<lang>: .../qwerty` rather than the Kaitag pattern of a custom layout + language_key_texts. **Net: 13 lines across 3 files.**

- **`method.xml`** — `<subtype>` entry for `tok` between the existing `th` (Thai) and `tl` (Tagalog) blocks, plus the matching `tok: Toki Pona/qwerty` line in the supported-subtypes documentation comment at the top. The subtypeId `0x67e4505d` is the Java-compatible `Arrays.hashCode` of the `(locale, mode, extraValue, isAuxiliary, overridesImplicitlyEnabledSubtype, isAsciiCapable)` tuple Android uses internally; verified non-colliding against the existing 129 subtypeIds.
- **`LocaleUtils.kt`** — `"tok" -> R.string.subtype_tok` override in `Locale.localizedDisplayName`. Without it, older Android versions (< CLDR 42, which is where Toki Pona's display name first landed) would show `tok` instead of "Toki Pona" in the picker. Matches how `mns`/`xdq`/`dru`/`st`/`dag`/`mhr` are handled; the existing CLDR-fallback comment at the bottom of that block explicitly flags this as the needed pattern for ISO 639-3 codes with thin Android coverage.
- **`strings.xml`** — `subtype_tok = "Toki Pona"` with the standard Wikipedia-link doc comment that every other `subtype_<code>` entry has.

## What's intentionally **not** changed

- **No new layout file.** The qwerty layout already covers Toki Pona's alphabet; adding a custom one would just duplicate qwerty with `q`/`z`/etc. unmapped and lose users access to those keys when typing English in mixed content — which is a real Toki Pona usage pattern.
- **`ScriptUtils.kt` is unchanged.** Its `else -> SCRIPT_LATIN` fallback already classifies `tok` correctly, and the explicit cyrillic list doesn't include it.
- **No `language_key_texts/` file.** That directory was refactored away after #748 and isn't part of the current build.

## Testing

The change is a 13-line resource + locale-map addition with no behavioral logic, so I'm submitting without a local build to verify — happy to run any specific CI check or manual test you'd like before merge. Also happy to adjust the subtypeId, swap qwerty for a different default layout, or add a separate small Toki Pona layout file if you'd prefer a dedicated one over `qwerty`.

Per @IamBugs's separate report of a crash when selecting the Toki Pona dictionary under "No Language" — your earlier comment in #2502 mentioned the underlying weirdness may already be fixed for 4.0; that should now be moot once this lands since Toki Pona has its own subtype.