### PR TITLE
Fix crash on long-press when a placeholder is the only popup key

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/Key.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/Key.java
@@ -1123,7 +1123,7 @@ public class Key implements Comparable<Key> {
             final String[] popupKeys = PopupKeysUtilsKt.createPopupKeysArray(popupSet, mKeyboardParams, label != null ? label : keySpec);
             mPopupKeysColumnAndFlags = getPopupKeysColumnAndFlagsAndSetNullInArray(params, popupKeys);
             final String[] finalPopupKeys = popupKeys == null ? null : PopupKeySpec.filterOutEmptyString(popupKeys);
-            if (finalPopupKeys != null) {
+            if (finalPopupKeys != null && finalPopupKeys.length > 0) {
                 actionFlags |= ACTION_FLAGS_ENABLE_LONG_PRESS;
                 mPopupKeys = new PopupKeySpec[finalPopupKeys.length];
                 for (int i = 0; i < finalPopupKeys.length; i++) {

--- a/app/src/test/java/helium314/keyboard/KeyboardParserTest.kt
+++ b/app/src/test/java/helium314/keyboard/KeyboardParserTest.kt
@@ -437,6 +437,27 @@ f""", // no newline at the end
         }
     }
 
+    @Test fun placeholderAsOnlyPopup() { // https://github.com/HeliBorg/HeliBoard/issues/1324
+        val keyParams = LayoutParser.parseJsonString("""[[{ "label": "ক", "popup": { "relevant": [
+       { "type": "placeholder" }
+      ]
+    } }]]""").flatMap { row -> row.mapNotNull { it.compute(params)?.toKeyParams(params) } }.single()
+        assertEquals(null, keyParams.mPopupKeys)
+        keyParams.mAbsoluteWidth = 1f
+        keyParams.mAbsoluteHeight = 1f
+        val key = keyParams.createKey()
+        assertEquals(false, key.isLongPressEnabled)
+    }
+
+    @Test fun placeholderNextToOtherPopup() {
+        val key = LayoutParser.parseJsonString("""[[{ "label": "ক", "popup": { "relevant": [
+       { "type": "placeholder" }, { "label": "k" }
+      ]
+    } }]]""").flatMap { row -> row.mapNotNull { it.compute(params) } }.single()
+        assertEquals(1, key.toKeyParams(params).mPopupKeys?.size)
+        assertEquals("k", key.toKeyParams(params).mPopupKeys?.first()?.mLabel)
+    }
+
     @Test fun popupSymbolAlpha() {
         val key = LayoutParser.parseJsonString("""[[{ "label": "c", "popup": {
           "main": { "code":   -10001, "label": "x" }


### PR DESCRIPTION
Fixes #1324.

### Problem
When a key has a `placeholder` popup as its **only** popup key, and the popup key order is set so that only "Layout" popups are used, long-pressing the key crashes the keyboard.

Reproduction (from #1324):
```json
{ "label": "ক", "popup": { "relevant": [ { "type": "placeholder" } ] } }
```
1. Use a layout with such a key.
2. Settings → set popup key order to "Layout" only.
3. Long-press the key.

### Cause
`createPopupKeysArray` produces a non-empty array for the placeholder, but the placeholder resolves to an empty string. After `PopupKeySpec.filterOutEmptyString(...)` removes it, the result is an **empty (but non-null)** array. `Key.KeyParams` then still sets `ACTION_FLAGS_ENABLE_LONG_PRESS`, so a long-press opens a popup keyboard with zero keys, which throws in `PopupKeysKeyboard.Builder` (division by / layout for zero columns).

### Fix
Only enable long-press / build `mPopupKeys` when the filtered array is actually non-empty:

```java
if (finalPopupKeys != null && finalPopupKeys.length > 0) {
```

This makes a placeholder-only popup set behave like "no popups", matching the expected behaviour described in the issue (long-press does nothing instead of crashing).

### Tests
Added two tests to `ParserTest`:
- `placeholderAsOnlyPopup` – a placeholder-only popup set yields `mPopupKeys == null` and long-press disabled (this crashed before the fix).
- `placeholderNextToOtherPopup` – a placeholder alongside a real popup key keeps only the real key.

All unit tests pass (`testRunTestsUnitTest`).
