### PR TITLE
Always show emoji category tabs, decouple them from toolbar hiding

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
@@ -358,7 +358,9 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         // @see LatinIME#onComputeInset(android.inputmethodservice.InputMethodService.Insets)
         mKeyboardView.setVisibility(View.GONE);
         mSuggestionStripView.setVisibility(View.GONE);
-        mStripContainer.setVisibility(getSecondaryStripVisibility());
+        // the strip container always shows the emoji category tab strip in emoji view,
+        // independent of toolbar settings
+        mStripContainer.setVisibility(View.VISIBLE);
         mClipboardStripScrollView.setVisibility(View.GONE);
         mEmojiTabStripView.setVisibility(View.VISIBLE);
         mClipboardHistoryView.setVisibility(View.GONE);
@@ -380,7 +382,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         mKeyboardView.setVisibility(View.GONE);
         mEmojiTabStripView.setVisibility(View.GONE);
         mSuggestionStripView.setVisibility(View.GONE);
-        mStripContainer.setVisibility(getSecondaryStripVisibility());
+        mStripContainer.setVisibility(getClipboardStripVisibility());
         mClipboardStripScrollView.post(() -> mClipboardStripScrollView.fullScroll(HorizontalScrollView.FOCUS_RIGHT));
         mClipboardStripScrollView.setVisibility(View.VISIBLE);
         mEmojiPalettesView.setVisibility(View.GONE);
@@ -586,8 +588,8 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         }
     }
 
-    private static int getSecondaryStripVisibility() {
-        return Settings.getValues().mSecondaryStripVisible? View.VISIBLE : View.GONE;
+    private static int getClipboardStripVisibility() {
+        return Settings.getValues().mClipboardStripVisible? View.VISIBLE : View.GONE;
     }
 
     // Displays a toast-like message with the provided text for a specified duration.

--- a/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardHistoryView.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardHistoryView.kt
@@ -70,7 +70,7 @@ class ClipboardHistoryView @JvmOverloads constructor(
         val keyboardViewAttr = context.obtainStyledAttributes(attrs, R.styleable.KeyboardView, defStyle, R.style.KeyboardView)
         keyBackgroundId = keyboardViewAttr.getResourceId(R.styleable.KeyboardView_keyBackground, 0)
         keyboardViewAttr.recycle()
-        if (Settings.getValues().mSecondaryStripVisible) {
+        if (Settings.getValues().mClipboardStripVisible) {
             getEnabledClipboardToolbarKeys(context.prefs())
                 .forEach { toolbarKeys.add(createToolbarKey(context, it)) }
         }
@@ -82,7 +82,7 @@ class ClipboardHistoryView @JvmOverloads constructor(
         val res = context.resources
         // The main keyboard expands to the entire this {@link KeyboardView}.
         val width = ResourceUtils.getKeyboardWidth(context, Settings.getValues()) + paddingLeft + paddingRight
-        val height = ResourceUtils.getSecondaryKeyboardHeight(res, Settings.getValues()) + paddingTop + paddingBottom
+        val height = ResourceUtils.getKeyboardHeight(res, Settings.getValues()) + paddingTop + paddingBottom
         setMeasuredDimension(width, height)
     }
 

--- a/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardLayoutParams.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardLayoutParams.kt
@@ -21,7 +21,7 @@ class ClipboardLayoutParams(ctx: Context) {
     init {
         val res = ctx.resources
         val sv = Settings.getValues()
-        val defaultKeyboardHeight = ResourceUtils.getSecondaryKeyboardHeight(res, sv)
+        val defaultKeyboardHeight = ResourceUtils.getKeyboardHeight(res, sv)
         val defaultKeyboardWidth = ResourceUtils.getKeyboardWidth(ctx, sv)
 
         keyVerticalGap = (res.getFraction(R.fraction.config_key_vertical_gap_holo,

--- a/app/src/main/java/helium314/keyboard/keyboard/emoji/EmojiLayoutParams.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/emoji/EmojiLayoutParams.kt
@@ -22,7 +22,7 @@ internal class EmojiLayoutParams(res: Resources) {
 
     init {
         val sv = Settings.getValues()
-        val defaultKeyboardHeight = ResourceUtils.getSecondaryKeyboardHeight(res, sv)
+        val defaultKeyboardHeight = ResourceUtils.getKeyboardHeight(res, sv)
 
         val keyVerticalGap = (res.getFraction(R.fraction.config_key_vertical_gap_holo,
             defaultKeyboardHeight, defaultKeyboardHeight) * sv.mKeyGapScale).toInt()

--- a/app/src/main/java/helium314/keyboard/keyboard/emoji/EmojiPalettesView.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/emoji/EmojiPalettesView.java
@@ -229,7 +229,7 @@ public final class EmojiPalettesView extends LinearLayout
         // The main keyboard expands to the entire this {@link KeyboardView}.
         final int width = ResourceUtils.getKeyboardWidth(getContext(), Settings.getValues())
                 + getPaddingLeft() + getPaddingRight();
-        final int height = ResourceUtils.getSecondaryKeyboardHeight(res, Settings.getValues())
+        final int height = ResourceUtils.getKeyboardHeight(res, Settings.getValues())
                 + getPaddingTop() + getPaddingBottom();
         mEmojiCategoryPageIndicatorView.mWidth = width;
         setMeasuredDimension(width, height);
@@ -253,10 +253,8 @@ public final class EmojiPalettesView extends LinearLayout
         if (initialized) return;
         mEmojiCategory.initialize();
         mTabStrip = (LinearLayout) KeyboardSwitcher.getInstance().getEmojiTabStrip();
-        if (Settings.getValues().mSecondaryStripVisible) {
-            for (EmojiCategory.CategoryProperties properties : mEmojiCategory.getShownCategories()) {
-                addTab(mTabStrip, properties.getCategory());
-            }
+        for (EmojiCategory.CategoryProperties properties : mEmojiCategory.getShownCategories()) {
+            addTab(mTabStrip, properties.getCategory());
         }
 
         mPager = findViewById(R.id.emoji_pager);
@@ -430,15 +428,13 @@ public final class EmojiPalettesView extends LinearLayout
                                 mEmojiCategory.getCurrentCategory()), ! initial && ! isAnimationsDisabled());
             }
 
-            if (Settings.getValues().mSecondaryStripVisible) {
-                View old = mTabStrip.findViewWithTag(oldCategory);
-                View current = mTabStrip.findViewWithTag(category);
+            View old = mTabStrip.findViewWithTag(oldCategory);
+            View current = mTabStrip.findViewWithTag(category);
 
-                if (old instanceof ImageView)
-                    Settings.getValues().mColors.setColor((ImageView) old, ColorType.EMOJI_CATEGORY);
-                if (current instanceof ImageView)
-                    Settings.getValues().mColors.setColor((ImageView) current, ColorType.EMOJI_CATEGORY_SELECTED);
-            }
+            if (old instanceof ImageView)
+                Settings.getValues().mColors.setColor((ImageView) old, ColorType.EMOJI_CATEGORY);
+            if (current instanceof ImageView)
+                Settings.getValues().mColors.setColor((ImageView) current, ColorType.EMOJI_CATEGORY_SELECTED);
         }
     }
 

--- a/app/src/main/java/helium314/keyboard/latin/AppUpgrade.kt
+++ b/app/src/main/java/helium314/keyboard/latin/AppUpgrade.kt
@@ -696,6 +696,9 @@ private object AppUpgrade {
                 remove("narrow_key_gaps")
             }
         }
+        if (oldVersion <= 4003) {
+            prefs.edit { remove("toolbar_hiding_global") }
+        }
         upgradeToolbarPrefs(prefs)
         LayoutUtilsCustom.onLayoutFileChanged() // just to be sure
         prefs.edit { putInt(Settings.PREF_VERSION_CODE, BuildConfig.VERSION_CODE) }

--- a/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
@@ -163,7 +163,6 @@ object Defaults {
     const val PREF_URL_DETECTION = false
     const val PREF_DONT_SHOW_MISSING_DICTIONARY_DIALOG = false
     const val PREF_TOOLBAR_MODE = "EXPANDABLE"
-    const val PREF_TOOLBAR_HIDING_GLOBAL = true
     const val PREF_TOOLBAR_SWIPE_DOWN_TO_HIDE = false
     const val PREF_QUICK_PIN_TOOLBAR_KEYS = false
     val PREF_PINNED_TOOLBAR_KEYS = defaultPinnedToolbarPref

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -192,7 +192,6 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_SPACE_BAR_TEXT = "space_bar_text";
     public static final String PREF_TIMESTAMP_FORMAT = "timestamp_format";
     public static final String PREF_TOOLBAR_MODE = "toolbar_mode";
-    public static final String PREF_TOOLBAR_HIDING_GLOBAL = "toolbar_hiding_global";
     public static final String PREF_TOOLBAR_SWIPE_DOWN_TO_HIDE = "toolbar_swipe_down_to_hide";
     public static final String PREF_SPELLCHECK_SUGGEST = "spellcheck_suggest";
     public static final String PREF_SHOW_ONLY_TOOLBAR_WITH_HARDWARE_KEYBOARD = "only_toolbar_with_hw_keyboard";

--- a/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
@@ -128,7 +128,6 @@ public class SettingsValues {
     public final float mSidePaddingScale;
     public final ToolbarMode mToolbarMode;
     public final boolean mToolbarSwipeDownToHide;
-    public final boolean mToolbarHidingGlobal;
     public final boolean mAutoShowToolbar;
     public final boolean mAutoHideToolbar;
     public final boolean mAlphaAfterEmojiInEmojiView;
@@ -152,7 +151,7 @@ public class SettingsValues {
 
     // Deduced settings
     public final boolean mSuggestionStripHiddenPerUserSettings;
-    public final boolean mSecondaryStripVisible;
+    public final boolean mClipboardStripVisible;
     public final int mKeypressVibrationDuration;
     public final float mKeypressSoundVolume;
     public final boolean mAutoCorrectionEnabledPerUserSettings;
@@ -188,7 +187,6 @@ public class SettingsValues {
         // we want to hide the toolbar / suggestion strip entirely if device is locked
         mToolbarMode = mIsLocked ? ToolbarMode.HIDDEN : Settings.readToolbarMode(prefs);
         mToolbarSwipeDownToHide = prefs.getBoolean(Settings.PREF_TOOLBAR_SWIPE_DOWN_TO_HIDE, Defaults.PREF_TOOLBAR_SWIPE_DOWN_TO_HIDE);
-        mToolbarHidingGlobal = mIsLocked || prefs.getBoolean(Settings.PREF_TOOLBAR_HIDING_GLOBAL, Defaults.PREF_TOOLBAR_HIDING_GLOBAL);
         mAutoCap = prefs.getBoolean(Settings.PREF_AUTO_CAP, Defaults.PREF_AUTO_CAP) && ScriptUtils.scriptSupportsUppercase(mLocale);
         mVibrateOn = Settings.readVibrationEnabled(prefs);
         mVibrateInDndMode = prefs.getBoolean(Settings.PREF_VIBRATE_IN_DND_MODE, Defaults.PREF_VIBRATE_IN_DND_MODE);
@@ -268,7 +266,7 @@ public class SettingsValues {
                   || !prefs.getBoolean(Settings.PREF_ALWAYS_SHOW_SUGGESTIONS_EXCEPT_WEB_TEXT, Defaults.PREF_ALWAYS_SHOW_SUGGESTIONS_EXCEPT_WEB_TEXT));
         mSuggestionsEnabled = prefs.getBoolean(Settings.PREF_SHOW_SUGGESTIONS, Defaults.PREF_SHOW_SUGGESTIONS)
             && (mInputAttributes.mShouldShowSuggestions || mOverrideShowingSuggestions) && !mSuggestionStripHiddenPerUserSettings;
-        mSecondaryStripVisible = mToolbarMode != ToolbarMode.HIDDEN || ! mToolbarHidingGlobal;
+        mClipboardStripVisible = mToolbarMode != ToolbarMode.HIDDEN;
         mIncognitoModeEnabled = prefs.getBoolean(Settings.PREF_ALWAYS_INCOGNITO_MODE, Defaults.PREF_ALWAYS_INCOGNITO_MODE) || mInputAttributes.mNoLearning
                 || mInputAttributes.mIsPasswordField;
         mBottomRowScale = Settings.readBottomRowScale(prefs, isLandscape, isFolded);

--- a/app/src/main/java/helium314/keyboard/latin/utils/ResourceUtils.java
+++ b/app/src/main/java/helium314/keyboard/latin/utils/ResourceUtils.java
@@ -59,15 +59,6 @@ public final class ResourceUtils {
         return windowBounds.width() - insets.left - insets.right;
     }
 
-    public static int getSecondaryKeyboardHeight(final Resources res, final SettingsValues settingsValues) {
-        final int keyboardHeight = getKeyboardHeight(res, settingsValues);
-        if (settingsValues.mToolbarMode == ToolbarMode.HIDDEN && ! settingsValues.mToolbarHidingGlobal) {
-            // Small adjustment to match the height of the main keyboard which has a hidden strip container.
-            return keyboardHeight - (int) res.getDimension(R.dimen.config_suggestions_strip_height);
-        }
-        return keyboardHeight;
-    }
-
     public static int getKeyboardHeight(Resources res, SettingsValues settingsValues) {
         if (settingsValues.mIsFloatingKeyboard) {
             return settingsValues.mFloatingHeight;

--- a/app/src/main/java/helium314/keyboard/settings/screens/ToolbarScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/ToolbarScreen.kt
@@ -44,10 +44,8 @@ fun ToolbarScreen(
         Log.v("irrelevant", "stupid way to trigger recomposition on preference change")
     val toolbarMode = Settings.readToolbarMode(prefs)
     val clipboardToolbarVisible = toolbarMode != ToolbarMode.HIDDEN
-        || !prefs.getBoolean(Settings.PREF_TOOLBAR_HIDING_GLOBAL, Defaults.PREF_TOOLBAR_HIDING_GLOBAL)
     val items = listOf(
         Settings.PREF_TOOLBAR_MODE,
-        if (toolbarMode == ToolbarMode.HIDDEN) Settings.PREF_TOOLBAR_HIDING_GLOBAL else null,
         if (toolbarMode != ToolbarMode.HIDDEN) Settings.PREF_TOOLBAR_SWIPE_DOWN_TO_HIDE else null,
         when (toolbarMode) {
              ToolbarMode.EXPANDABLE, ToolbarMode.TOOLBAR_KEYS -> Settings.PREF_TOOLBAR_KEYS
@@ -82,11 +80,6 @@ fun createToolbarSettings(context: Context) = listOf(
             items,
             Defaults.PREF_TOOLBAR_MODE
         ) {
-            KeyboardSwitcher.getInstance().setThemeNeedsReload()
-        }
-    },
-    Setting(context, Settings.PREF_TOOLBAR_HIDING_GLOBAL, R.string.toolbar_hiding_global) {
-        SwitchPreference(it, Defaults.PREF_TOOLBAR_HIDING_GLOBAL) {
             KeyboardSwitcher.getInstance().setThemeNeedsReload()
         }
     },

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -428,7 +428,6 @@
     <string name="toolbar_mode_toolbar_keys">مفاتيح شريط الأدوات فقط</string>
     <string name="toolbar_mode_suggestion_strip">اقتراحات فقط</string>
     <string name="toolbar_mode_hidden">مخفي</string>
-    <string name="toolbar_hiding_global">أخفِ أشرطة أدوات الحافظة والرموز التعبيرية أيضًا</string>
     <string name="popup_order_and_hint_source">ترتيب مفاتيح النوافذ المنبثقة ومصدر التلميحات</string>
     <string name="landscape">أفقي</string>
     <string name="show_emoji_descriptions">أظهر وصف الرموز التعبيرية عند الضغط مطولاً</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -456,7 +456,6 @@
     <string name="toolbar_mode_suggestion_strip">Само предложения</string>
     <string name="toolbar_mode_hidden">Скрито</string>
     <string name="toolbar_mode_expandable">Клавиши и предложения в лентата с инструменти</string>
-    <string name="toolbar_hiding_global">Скриване и на лентите с инструменти за клипборда и емотиконите</string>
     <string name="landscape">Пейзаж</string>
     <string name="popup_order_and_hint_source">Ред на изскачащите клавиши и източник на съвети</string>
     <string name="show_emoji_descriptions">Показване на описание на емотикони при продължително натискане</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -417,7 +417,6 @@
     <string name="subtype_with_layout_generic">%1$s (%2$s)</string>
     <string name="toolbar_mode_expandable">টুলবার বোতাম ও পরামর্শ</string>
     <string name="toolbar_mode">টুলবার মোড</string>
-    <string name="toolbar_hiding_global">ক্লিপবোর্ড ও ইমোজি টুলবার আড়ালকরণ</string>
     <string name="toolbar_mode_toolbar_keys">কেবল টুলবার বোতাম</string>
     <string name="toolbar_mode_suggestion_strip">কেবল পরামর্শ</string>
     <string name="toolbar_mode_hidden">প্রচ্ছন্ন</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -415,7 +415,6 @@
     <string name="prefs_emoji_skin_tone_neutral">Neutre</string>
     <string name="subtype_with_layout_generic">%1$s (%2$s)</string>
     <string name="toolbar_mode_suggestion_strip">Només suggeriments</string>
-    <string name="toolbar_hiding_global">Amagar també el porta-retalls i les barres d\'eines d\'emojis</string>
     <string name="toolbar_mode">Mode barra d\'eines</string>
     <string name="toolbar_mode_expandable">Tecles de la barra d\'eines i suggeriments</string>
     <string name="toolbar_mode_toolbar_keys">Només tecles de la barra d\'eines</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -420,7 +420,6 @@
     <string name="toolbar_mode_toolbar_keys">Pouze klávesy panelu nástrojů</string>
     <string name="toolbar_mode_suggestion_strip">Pouze návrhy</string>
     <string name="toolbar_mode_hidden">Skryté</string>
-    <string name="toolbar_hiding_global">Skrýt také panely schránky a emoji</string>
     <string name="toolbar_mode">Režim panelu nástrojů</string>
     <string name="popup_order_and_hint_source">Pořadí vyskakovacích kláves a zdroj tipů</string>
     <string name="landscape">Na šířku</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -417,7 +417,6 @@
     <string name="toolbar_mode_toolbar_keys">Symbolleiste nur Tasten</string>
     <string name="popup_order_and_hint_source">Popup Tasten Reihenfolge und Vorschlag Quelle</string>
     <string name="toolbar_mode_hidden">Versteckt</string>
-    <string name="toolbar_hiding_global">Auch Zwischenablage und Emoji Symbolleisten verstecken</string>
     <string name="subtype_with_layout_generic">%1$s (%2$s)</string>
     <string name="landscape">Querformat</string>
     <string name="toolbar_mode_suggestion_strip">Nur Vorschläge</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -427,7 +427,6 @@
     <string name="landscape">Horizontal</string>
     <string name="toolbar_mode_suggestion_strip" tools:keep="@string/toolbar_mode_suggestion_strip">Solo sugerencias</string>
     <string name="toolbar_mode_hidden" tools:keep="@string/toolbar_mode_hidden">Oculto</string>
-    <string name="toolbar_hiding_global">Oculta también las barras del portapapeles y los emojis</string>
     <string name="prefs_emoji_key_fit">Escala el tamaño de las teclas de emoticono al tamaño de la fuente</string>
     <string name="prefs_emoji_skin_tone">Tono de piel de emoticonos por defecto</string>
     <string name="prefs_emoji_skin_tone_neutral">Neutral</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -419,7 +419,6 @@
     <string name="toolbar_mode_expandable">Tööriistariba nupud ja soovitused</string>
     <string name="toolbar_mode_toolbar_keys">Ainult tööriistariba nupud</string>
     <string name="toolbar_mode_hidden">Peidetud</string>
-    <string name="toolbar_hiding_global">Peida ka lõikelaud ja emojide rida</string>
     <string name="popup_order_and_hint_source">Klahvide järjestus hüpikaknas ja vihjete allikas</string>
     <string name="landscape">Rõhtvaade</string>
     <string name="show_emoji_descriptions">Näita emojide kirjeldusi pika vajutusega</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -422,7 +422,6 @@
     <string name="show_emoji_descriptions">Erakutsi emojiaren deskribapena luze sakatzean</string>
     <string name="suggest_emojis_summary">Erabili emoji hiztegia iradokizun normaletan</string>
     <string name="suggest_emojis">Iradokitako emojiak</string>
-    <string name="toolbar_hiding_global">Ezkutatu arbela eta emojien tresna-barrak ere</string>
     <string name="toolbar_mode_toolbar_keys">Tresna-barrako gakoak bakarrik</string>
     <string name="toolbar_mode_expandable">Tresna-barrako gakoak eta iradokizunak</string>
     <string name="toolbar_mode_hidden">Ezkutuan</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -229,7 +229,6 @@
     <string name="toolbar_mode_toolbar_keys" tools:keep="@string/toolbar_mode_toolbar_keys">فقط کلیدهای نوار ابزار</string>
     <string name="toolbar_mode_suggestion_strip" tools:keep="@string/toolbar_mode_suggestion_strip">فقط پیشنهادها</string>
     <string name="toolbar_mode_hidden" tools:keep="@string/toolbar_mode_hidden">پنهان</string>
-    <string name="toolbar_hiding_global">پنهان کردن نوار ابزارهای کلیپ‌بورد و ایموجی</string>
     <string name="toolbar_keys">انتخاب کلیدهای نوار ابزار</string>
     <string name="clipboard" tools:keep="@string/clipboard">کلیپ‌بورد</string>
     <string name="clear_clipboard" tools:keep="@string/clear_clipboard">پاک کردن کلیپ‌بورد</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -295,7 +295,6 @@
     <string name="save_subtype_per_app">Muista kieli sovelluskohtaisesti</string>
     <string name="toolbar_mode_suggestion_strip" tools:keep="@string/toolbar_mode_suggestion_strip">Vain ehdotukset</string>
     <string name="toolbar_mode_hidden" tools:keep="@string/toolbar_mode_hidden">Piilotettu</string>
-    <string name="toolbar_hiding_global">Piilota myös leikepöytä- ja emojipalkit</string>
     <string name="prefs_font_scale">Näppäimistön fontin skaalaus</string>
     <string name="prefs_emoji_font_scale">Emojinäkymän fontin skaalaus</string>
     <string name="prefs_emoji_skin_tone_neutral">Neutraali</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -423,7 +423,6 @@ Nouveau dictionnaire:
     <string name="toolbar_mode_toolbar_keys">Touches de la barre d\'outils uniquement</string>
     <string name="toolbar_mode_suggestion_strip">Suggestions uniquement</string>
     <string name="toolbar_mode_hidden">Masquée</string>
-    <string name="toolbar_hiding_global">Masquer également le presse-papiers et les barres d\'outils émoji</string>
     <string name="toolbar_mode_expandable">Touches de la barre d\'outil et suggestions</string>
     <string name="landscape">Paysage</string>
     <string name="popup_order_and_hint_source">Ordre des touches popup et source des symboles</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -431,7 +431,6 @@
     <string name="prefs_emoji_skin_tone">Tono de pel por defecto para emojis</string>
     <string name="prefs_emoji_skin_tone_neutral">Neutro</string>
     <string name="show_emoji_descriptions">Mostrar descrición do emoji con pulsación longa</string>
-    <string name="toolbar_hiding_global">Ocultar tamén as barras de ferramentas de emoji e portapapeis</string>
     <string name="suggest_emojis">Suxerir emojis</string>
     <string name="suggest_emojis_summary">Usar dicionario de emoji nas suxestións normais</string>
     <string name="suggest_punctuation">Suxestións de puntuación</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -224,7 +224,6 @@
     <string name="toolbar_mode_toolbar_keys" tools:keep="@string/toolbar_mode_toolbar_keys">Samo tipke alatne trake</string>
     <string name="toolbar_mode_suggestion_strip" tools:keep="@string/toolbar_mode_suggestion_strip">Samo prijedlozi</string>
     <string name="toolbar_mode_hidden" tools:keep="@string/toolbar_mode_hidden">Sakriveno</string>
-    <string name="toolbar_hiding_global">Sakrij i alatne trake međuspremnika i emojija</string>
     <string name="toolbar_keys">Odaberi tipke alatne trake</string>
     <string name="clipboard" tools:keep="@string/clipboard">Međuspremnik</string>
     <string name="clear_clipboard" tools:keep="@string/clear_clipboard">Očisti međuspremnik</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -366,7 +366,6 @@
     <string name="shift_removes_autospace">Shift billentyű leütésekor nincs automatikus szóköz</string>
     <string name="shift_removes_autospace_summary">A Shift billentyű eltávolítja a függőben lévő automatikus szóközt</string>
     <string name="show_popup_keys_main">Nagyon gyakori változatok hozzáadása (alapértelmezett)</string>
-    <string name="toolbar_hiding_global">Vágólap- és emodzsisáv elrejtése</string>
     <string name="split" tools:keep="@string/split">Osztott billentyűzet</string>
     <string name="word_left" tools:keep="@string/word_left">Balra lévő szó</string>
     <string name="word_right" tools:keep="@string/word_right">Jobbra lévő szó</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -425,7 +425,6 @@
     <string name="toolbar_mode_expandable">Tasti funzione e suggerimenti</string>
     <string name="toolbar_mode_toolbar_keys">Solo tasti funzione</string>
     <string name="toolbar_mode_hidden">Nascosta</string>
-    <string name="toolbar_hiding_global">Nascondi anche le barre degli appunti e delle emoji</string>
     <string name="landscape">Orizzontale</string>
     <string name="popup_order_and_hint_source">Ordine dei caratteri popup e fonti dei suggerimenti</string>
     <string name="toolbar_mode_suggestion_strip">Solo suggerimenti</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -417,7 +417,6 @@
     <string name="landscape">במצב אופקי</string>
     <string name="toolbar_mode_suggestion_strip">הצעות בלבד</string>
     <string name="toolbar_mode_hidden">מוסתר</string>
-    <string name="toolbar_hiding_global">הסתרת סרגלי כלי הלוח והאמוג\'ים גם</string>
     <string name="toolbar_mode">מצב סרגל הכלים</string>
     <string name="toolbar_mode_expandable">פקדי סרגל הכלים והצעות</string>
     <string name="toolbar_mode_toolbar_keys">פקדי סרגל הכלים בלבד</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -218,7 +218,6 @@
     <string name="toolbar_mode_toolbar_keys">Tik įrankių juostos mygtukai</string>
     <string name="toolbar_mode_suggestion_strip">Tik pasiūlymai</string>
     <string name="toolbar_mode_hidden">Paslėpta</string>
-    <string name="toolbar_hiding_global">Paslėpti iškarpinę ir jaustukų įrankių juostą</string>
     <string name="toolbar_keys">Pasirinkti įrankių juostos mygtukus</string>
     <string name="clipboard" tools:keep="@string/clipboard">iškarpinė</string>
     <string name="clear_clipboard" tools:keep="@string/clear_clipboard">Išvalyti iškarpinę</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -186,7 +186,6 @@
     <string name="toolbar_mode_toolbar_keys">Kekunci bar alat sahaja</string>
     <string name="toolbar_mode_suggestion_strip">Cadangan sahaja</string>
     <string name="toolbar_mode_hidden">Tersembunyi</string>
-    <string name="toolbar_hiding_global">Sembunyi papan klip dan bar alat emoji juga</string>
     <string name="toolbar_keys">Pilih kekunci bar alat</string>
     <string name="clipboard" tools:keep="@string/clipboard">Papan klip</string>
     <string name="clear_clipboard" tools:keep="@string/clear_clipboard">Kosongkan papan klip</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -348,7 +348,6 @@
     <string name="toolbar_mode_toolbar_keys" tools:keep="@string/toolbar_mode_toolbar_keys">Kun verktøylinjetaster</string>
     <string name="toolbar_mode_suggestion_strip" tools:keep="@string/toolbar_mode_suggestion_strip">Kun forslag</string>
     <string name="toolbar_mode_hidden" tools:keep="@string/toolbar_mode_hidden">Skjult</string>
-    <string name="toolbar_hiding_global">Skjul verktøylinje for utklippstavle og emoji</string>
     <string name="split" tools:keep="@string/split">Oppdelt tastatur</string>
     <string name="page_start" tools:keep="@string/page_start">Sidestart</string>
     <string name="page_end" tools:keep="@string/page_end">Sideslutt</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -463,7 +463,6 @@
     <string name="toolbar_mode_toolbar_keys">Alleen werkbalktoetsen</string>
     <string name="toolbar_mode_suggestion_strip">Alleen suggesties</string>
     <string name="toolbar_mode_hidden">Verborgen</string>
-    <string name="toolbar_hiding_global">Klembord- en emoji-werkbalken ook verbergen</string>
     <string name="popup_order_and_hint_source">Popup toetsvolgorde en bron van hints</string>
     <string name="landscape">Liggend</string>
     <string name="show_emoji_descriptions">Toon emoji-beschrijving bij lang indrukken</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -463,7 +463,6 @@
     <string name="toolbar_mode_toolbar_keys">Tylko klawisze</string>
     <string name="toolbar_mode_suggestion_strip">Tylko sugestie</string>
     <string name="toolbar_mode_hidden">Ukryty</string>
-    <string name="toolbar_hiding_global">Ukryj także paski schowka i emotikonów</string>
     <string name="landscape">Poziomo</string>
     <string name="popup_order_and_hint_source">Kolejność wyskakujących okienek i źródło wskazówek</string>
     <string name="show_emoji_descriptions">Pokaż opis emoji po długim naciśnięciu</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -424,7 +424,6 @@
     <string name="prefs_emoji_skin_tone_neutral">Neutra</string>
     <string name="subtype_with_layout_generic">%1$s (%2$s)</string>
     <string name="toolbar_mode">Modo da barra de ferramentas</string>
-    <string name="toolbar_hiding_global">Ocultar a área de transferência e as barras de ferramentas de emoji também</string>
     <string name="toolbar_mode_expandable">Teclas da barra de ferramentas e sugestões</string>
     <string name="toolbar_mode_toolbar_keys">Somente teclas da barra de ferramentas</string>
     <string name="toolbar_mode_suggestion_strip">Somente sugestões</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -422,7 +422,6 @@
     <string name="toolbar_mode">Modo da barra de ferramentas</string>
     <string name="popup_order_and_hint_source">Ordem das teclas de popup e fonte de dicas</string>
     <string name="toolbar_mode_expandable">Teclas da barra de ferramentas e sugestões</string>
-    <string name="toolbar_hiding_global">Ocultar a área de transferência e as barras de ferramentas de emoji</string>
     <string name="subtype_with_layout_generic">%1$s (%2$s)</string>
     <string name="subtype_generic_extended">%s (Extendido)</string>
     <string name="subtype_probhat_bn_BD">%s (Probhat)</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -228,7 +228,6 @@
     <string name="down" tools:keep="@string/down">Baixo</string>
     <string name="word_left" tools:keep="@string/word_left">Palavra à esquerda</string>
     <string name="toolbar_mode_hidden">Escondido</string>
-    <string name="toolbar_hiding_global">Esconder a área de transferência e barras de ferramentas de emoji também</string>
     <string name="toolbar_keys">Selecionar teclas da barra de ferramentas</string>
     <string name="voice" tools:keep="@string/voice">Entrada de voz</string>
     <string name="toolbar_mode_toolbar_keys">Só teclas da barra de ferramentas</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -423,7 +423,6 @@
     <string name="toolbar_mode_toolbar_keys">Doar tastele barei de instrumente</string>
     <string name="toolbar_mode_suggestion_strip">Doar sugestii</string>
     <string name="toolbar_mode_hidden">Ascuns</string>
-    <string name="toolbar_hiding_global">Ascunde și barele de instrumente pentru clipboard și emoji-uri</string>
     <string name="about_wiki_link">Mergi la Wiki</string>
     <string name="about_wiki_link_description">Wiki-ul poate fi îmbunătățit de orice utilizator GitHub!</string>
     <string name="landscape">Peisaj</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -419,7 +419,6 @@
     <string name="toolbar_mode_toolbar_keys">Только клавиши</string>
     <string name="toolbar_mode_suggestion_strip">Только подсказки</string>
     <string name="toolbar_mode_hidden">Скрыть</string>
-    <string name="toolbar_hiding_global">Скрыть панели инструментов буфера обмена и эмодзи</string>
     <string name="popup_order_and_hint_source">Порядок всплывающих клавиш и источник подсказок</string>
     <string name="landscape">Альбомный режим</string>
     <string name="show_emoji_descriptions">Показывать описание эмодзи при долгом нажатии</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -217,7 +217,6 @@
     <string name="toolbar_mode_toolbar_keys" tools:keep="@string/toolbar_mode_toolbar_keys">கருவிப்பட்டி விசைகள் மட்டுமே</string>
     <string name="toolbar_mode_suggestion_strip" tools:keep="@string/toolbar_mode_suggestion_strip">பரிந்துரைகள் மட்டுமே</string>
     <string name="toolbar_mode_hidden" tools:keep="@string/toolbar_mode_hidden">மறைக்கப்பட்டது</string>
-    <string name="toolbar_hiding_global">இடைநிலைப்பலகை மற்றும் ஈமோசி கருவிப்பட்டிகளையும் மறைக்கவும்</string>
     <string name="toolbar_keys">கருவிப்பட்டி விசைகளைத் தேர்ந்தெடுக்கவும்</string>
     <string name="clipboard" tools:keep="@string/clipboard">இடைநிலைப் பலகை</string>
     <string name="clear_clipboard" tools:keep="@string/clear_clipboard">கிளிப்போர்டை அழிக்கவும்</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -380,7 +380,6 @@
     <string name="toolbar_mode_toolbar_keys">Yalnızca araç çubuğu tuşları</string>
     <string name="toolbar_mode_suggestion_strip">Yalnızca öneriler</string>
     <string name="toolbar_mode_hidden">Gizli</string>
-    <string name="toolbar_hiding_global">Pano ve emoji araç çubuklarını da gizle</string>
     <string name="prefs_font_scale">Klavye yazı tipi boyutu</string>
     <string name="custom_font">Dosyadan özel yazı tipi seç</string>
     <string name="prefs_key_emoji_max_sdk">Emoji sürümünü geçersiz kıl</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -410,7 +410,6 @@
     <string name="toolbar_mode_toolbar_keys">Лише панель інструментів</string>
     <string name="toolbar_mode_suggestion_strip">Лише підказки</string>
     <string name="toolbar_mode_hidden">Приховано</string>
-    <string name="toolbar_hiding_global">Приховати панелі інструментів буфера обміну та емодзі</string>
     <string name="prefs_emoji_key_fit">Масштабувати розмір клавіші емодзі залежно від розміру шрифту</string>
     <string name="prefs_emoji_skin_tone">Тон шкіри емодзі за замовчуванням</string>
     <string name="prefs_emoji_skin_tone_neutral">Нейтральний (жовтий)</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -422,7 +422,6 @@
     <string name="toolbar_mode_toolbar_keys">仅工具栏键</string>
     <string name="toolbar_mode_suggestion_strip">仅建议</string>
     <string name="toolbar_mode_hidden">隐藏</string>
-    <string name="toolbar_hiding_global">同时隐藏剪贴板和表情符号工具栏</string>
     <string name="popup_order_and_hint_source">弹出键顺序和提示源</string>
     <string name="landscape">横屏</string>
     <string name="show_emoji_descriptions">长按时显示表情符号描述</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -339,8 +339,6 @@
     <string name="toolbar_mode_suggestion_strip" tools:keep="@string/toolbar_mode_suggestion_strip">Suggestions only</string>
     <!-- Option to set the toolbar mode to hidden -->
     <string name="toolbar_mode_hidden" tools:keep="@string/toolbar_mode_hidden">Hidden</string>
-    <!-- Option to hide clipboard and emoji toolbars when main toolbar is hidden -->
-    <string name="toolbar_hiding_global">Hide clipboard and emoji toolbars too</string>
     <!-- Title of the setting to set toolbar keys -->
     <string name="toolbar_keys">Select toolbar keys</string>
     <!-- Names of the toolbar keys-->


### PR DESCRIPTION
**Draft for discussion** – this reverses part of the design from #1606, so I'd like your opinion before polishing it.

### Motivation
With the toolbar hidden and "Hide clipboard and emoji toolbars too" enabled (which is the **default**, `PREF_TOOLBAR_HIDING_GLOBAL = true`), the emoji palette loses its category tab strip. Categories can then only be reached by swiping through every page, which users don't discover – see #2546 ("Can't find all list of emojis", diagnosed in-thread as exactly this setting).

The underlying issue: the emoji **category tab strip is navigation, not a toolbar**. It's the only way to jump between emoji categories, so hiding it as if it were a row of toolbar tools removes core functionality rather than just decluttering.

### Change
- **Emoji category tabs are now always shown** in the emoji view, as an anchor/extension on top of the keyboard, independent of the toolbar setting.
- The **clipboard toolbar** now simply follows the main toolbar setting: toolbar hidden → clipboard toolbar hidden. (Users who want clipboard toolbar keys can enable the toolbar.)
- Because the strips now either match the main view (clipboard) or are always shown (emoji tabs), the separate `toolbar_hiding_global` setting no longer has a distinct meaning and is **removed** (with a small migration in `AppUpgrade` to drop the stored pref). The secondary-keyboard height adjustment tied to it is no longer needed either.

This follows a "works best for most" approach: one less setting, and the emoji navigation is never accidentally hidden.

### Open questions
- Are you OK with dropping `toolbar_hiding_global`? The alternative is to keep the setting but make it only affect the **clipboard** toolbar (never the emoji category tabs). I went with removal for simplicity, but can switch to the narrower change if you'd prefer to keep the option.
- Height: since emoji/clipboard no longer subtract the strip height when the toolbar is hidden, both views keep the main keyboard height. I tested this on an emulator (Android 15) and the emoji view looks consistent, but a second look on real devices/floating mode is welcome.

### Testing
Built and tested on an emulator with the toolbar hidden:
- Emoji view now shows the category tab strip and category switching works (previously the strip was gone and only swiping changed category).
- No crashes switching between alpha / emoji views.

`assembleDebug` and `testRunTestsUnitTest` pass.

Refs #2546, #374, #1606.
