### PR TITLE
Add setting to disable URL/email specific layout

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardLayoutSet.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardLayoutSet.kt
@@ -238,7 +238,8 @@ class KeyboardLayoutSet internal constructor(private val mContext: Context, priv
                     }
                     InputType.TYPE_CLASS_PHONE -> KeyboardMode.PHONE
                     InputType.TYPE_CLASS_TEXT ->
-                        if (InputTypeUtils.isEmailVariation(variation)) KeyboardMode.EMAIL
+                        if (!Settings.getValues().mUrlEmailLayout) KeyboardMode.TEXT
+                        else if (InputTypeUtils.isEmailVariation(variation)) KeyboardMode.EMAIL
                         else if (variation == InputType.TYPE_TEXT_VARIATION_URI) KeyboardMode.URL
                         else KeyboardMode.TEXT
                     else -> KeyboardMode.TEXT

--- a/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
@@ -145,6 +145,7 @@ object Defaults {
     const val PREF_POPUP_KEYS_HINT_ORDER = POPUP_KEYS_LABEL_DEFAULT
     const val PREF_SHOW_POPUP_HINTS = false
     const val PREF_SHOW_TLD_POPUP_KEYS = true
+    const val PREF_URL_EMAIL_LAYOUT = true
     const val PREF_MORE_POPUP_KEYS = "main"
     const val PREF_SPACE_TO_CHANGE_LANG = true
     const val PREF_LANGUAGE_SWIPE_DISTANCE = 5

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -160,6 +160,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_SHOW_POPUP_HINTS = "show_popup_hints";
     public static final String PREF_MORE_POPUP_KEYS = "more_popup_keys";
     public static final String PREF_SHOW_TLD_POPUP_KEYS = "show_tld_popup_keys";
+    public static final String PREF_URL_EMAIL_LAYOUT = "url_email_layout";
 
     public static final String PREF_SPACE_TO_CHANGE_LANG = "prefs_long_press_keyboard_to_change_lang";
     public static final String PREF_LANGUAGE_SWIPE_DISTANCE = "language_swipe_distance";

--- a/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
@@ -73,6 +73,7 @@ public class SettingsValues {
     public final boolean mShowsHints;
     public final boolean mShowsPopupHints;
     public final boolean mShowTldPopupKeys;
+    public final boolean mUrlEmailLayout;
     public final boolean mSpaceForLangChange;
     public final boolean mShowsEmojiKey;
     public final boolean mVarToolbarDirection;
@@ -211,6 +212,7 @@ public class SettingsValues {
         mShowsHints = prefs.getBoolean(Settings.PREF_SHOW_HINTS, Defaults.PREF_SHOW_HINTS);
         mShowsPopupHints = prefs.getBoolean(Settings.PREF_SHOW_POPUP_HINTS, Defaults.PREF_SHOW_POPUP_HINTS);
         mShowTldPopupKeys = prefs.getBoolean(Settings.PREF_SHOW_TLD_POPUP_KEYS, Defaults.PREF_SHOW_TLD_POPUP_KEYS);
+        mUrlEmailLayout = prefs.getBoolean(Settings.PREF_URL_EMAIL_LAYOUT, Defaults.PREF_URL_EMAIL_LAYOUT);
         mSpaceForLangChange = prefs.getBoolean(Settings.PREF_SPACE_TO_CHANGE_LANG, Defaults.PREF_SPACE_TO_CHANGE_LANG);
         mShowsEmojiKey = prefs.getBoolean(Settings.PREF_SHOW_EMOJI_KEY, Defaults.PREF_SHOW_EMOJI_KEY);
         mVarToolbarDirection = mToolbarMode != ToolbarMode.HIDDEN && prefs.getBoolean(Settings.PREF_VARIABLE_TOOLBAR_DIRECTION, Defaults.PREF_VARIABLE_TOOLBAR_DIRECTION);

--- a/app/src/main/java/helium314/keyboard/settings/screens/PreferencesScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/PreferencesScreen.kt
@@ -50,6 +50,7 @@ fun PreferencesScreen(
         Settings.PREF_POPUP_KEYS_ORDER,
         Settings.PREF_SHOW_POPUP_HINTS,
         Settings.PREF_SHOW_TLD_POPUP_KEYS,
+        Settings.PREF_URL_EMAIL_LAYOUT,
         Settings.PREF_POPUP_ON,
         if (AudioAndHapticFeedbackManager.getInstance().hasVibrator())
             Settings.PREF_VIBRATE_ON else null,
@@ -108,6 +109,12 @@ fun createPreferencesSettings(context: Context) = listOf(
         R.string.show_tld_popup_keys_summary
     ) {
         SwitchPreference(it, Defaults.PREF_SHOW_TLD_POPUP_KEYS) { KeyboardSwitcher.getInstance().setThemeNeedsReload() }
+    },
+    Setting(
+        context, Settings.PREF_URL_EMAIL_LAYOUT, R.string.url_email_layout,
+        R.string.url_email_layout_summary
+    ) {
+        SwitchPreference(it, Defaults.PREF_URL_EMAIL_LAYOUT) { KeyboardSwitcher.getInstance().setThemeNeedsReload() }
     },
     Setting(context, Settings.PREF_SHOW_POPUP_HINTS, R.string.show_popup_hints, R.string.show_popup_hints_summary) {
         SwitchPreference(it, Defaults.PREF_SHOW_POPUP_HINTS) { KeyboardSwitcher.getInstance().setThemeNeedsReload() }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -393,6 +393,8 @@
     <string name="subtype_baishakhi_bn_IN">%s (Baisakhi)</string>
     <string name="show_tld_popup_keys">Zeige TLD-Popup-Tasten</string>
     <string name="show_tld_popup_keys_summary">Ersetze Punkt-Tastenpopups mit Top-Level-Domains wenn URLs und Mailadressen eingegeben werden</string>
+    <string name="url_email_layout">Layout für URL- und E-Mail-Felder anpassen</string>
+    <string name="url_email_layout_summary">Zeige in URL-Feldern eine Schrägstrich-Taste und in E-Mail-Feldern eine @-Taste (anstelle des Kommas) samt passender Popup-Tasten. Deaktivieren, um immer das normale Layout zu behalten.</string>
     <string name="prefs_always_show_suggestions_except_web_text">Nicht immer Vorschläge für Web-Editierfelder anzeigen</string>
     <string name="layout_number_row_basic" tools:keep="@string/layout_number_row_basic">Zahlenreihe (Basis)</string>
     <string name="prefs_always_show_suggestions_except_web_text_summary">Web-Eingabefelder (meist in Browsern) sind eine häufige Ursache für Probleme mit der Einstellung \"Immer Vorschläge anzeigen\"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -323,6 +323,10 @@
     <string name="show_tld_popup_keys">Show TLD popup keys</string>
     <!-- Description of the setting to show TLD popup keys -->
     <string name="show_tld_popup_keys_summary">Replace period key popups with top level domains when typing URLs and email addresses</string>
+    <!-- Title of the setting to adapt the keyboard layout in URL and email input fields -->
+    <string name="url_email_layout">Adapt layout for URL and email fields</string>
+    <!-- Description of the setting to adapt the keyboard layout in URL and email input fields -->
+    <string name="url_email_layout_summary">Show a slash key in URL fields and an @ key in email fields (in place of the comma), and matching popup keys. Disable to always keep the normal layout.</string>
     <!-- Names of the popup key classes -->
     <string name="popup_keys_number" tools:keep="@string/popup_keys_number">Number row</string>
     <string name="popup_keys_language" translatable="false" tools:keep="@string/popup_keys_language">@string/subtype_locale</string>


### PR DESCRIPTION
### What
Adds a preference **"Adapt layout for URL and email fields"** (default **on**, i.e. current behaviour). When turned off, `getKeyboardMode()` returns `TEXT` for URI and email input types, so the base layout and popups stay identical to a normal text field: the comma key stays a comma (no `/` or `@` swap), and no TLD popups are shown.

The whole change is a single gate in `KeyboardLayoutSet.getKeyboardMode()`:

```kotlin
InputType.TYPE_CLASS_TEXT ->
    if (!Settings.getValues().mUrlEmailLayout) KeyboardMode.TEXT
    else if (InputTypeUtils.isEmailVariation(variation)) KeyboardMode.EMAIL
    else if (variation == InputType.TYPE_TEXT_VARIATION_URI) KeyboardMode.URL
    else KeyboardMode.TEXT
```

plus the pref plumbing (`Settings`/`Defaults`/`SettingsValues`) and one `SwitchPreference` in the Preferences screen, next to "Show TLD popup keys".

### Why
In URL fields the comma key becomes `/` and in email fields `@` (the `variation_selector` in `functional_keys.json`). This is intentional and can already be reverted with a custom functional-keys layout, as pointed out in #1573 and #734.

However, some users specifically want a keyboard whose base layout never shifts depending on the field — muscle memory for the comma position being the main reason — and building a full custom functional-keys layout is a fairly heavy step for "please don't move my comma". This offers a one-switch opt-out for that preference, without changing anything for everyone else.

### Notes / open questions
- **Draft**, opening this mainly for a decision: is a built-in setting wanted here, or should this stay "customize your layout"? Happy to close if the latter.
- Default is unchanged behaviour → existing users see no difference.
- Scope choice: the switch disables the entire URL/email mode (base key **and** TLD popups), which matches "no automatic adaptation at all". If you'd rather it only kept the comma/period base keys but still showed TLD popups, I can narrow it to the `variation_selector` instead.
- English strings only; no translations touched.
- Builds cleanly (`:app:compileDebugSources`).

Refs #1573, #734.
