### PR TITLE
Layout stack

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListener.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListener.java
@@ -8,11 +8,14 @@ package helium314.keyboard.keyboard;
 
 import android.view.KeyEvent;
 
+import androidx.annotation.Nullable;
 import androidx.core.view.inputmethod.InputContentInfoCompat;
 
 import helium314.keyboard.event.HapticEvent;
+import helium314.keyboard.keyboard.internal.LayoutDirective;
 import helium314.keyboard.latin.common.Constants;
 import helium314.keyboard.latin.common.InputPointers;
+import helium314.keyboard.latin.utils.RecapitalizeMode;
 
 public interface KeyboardActionListener {
     /**
@@ -115,7 +118,8 @@ public interface KeyboardActionListener {
     boolean onHorizontalSpaceSwipe(int steps);
     boolean onVerticalSpaceSwipe(int steps);
     void onEndSpaceSwipe();
-    boolean toggleNumpad(boolean withSliding, boolean forceReturnToAlpha);
+    void toggleLayout(LayoutDirective.Utility layout, int autoCapsFlags, @Nullable RecapitalizeMode recapitalizeMode);
+    void onLongPressAlphaSymbolForNumpad();
 
     void onMoveDeletePointer(int steps);
     void onUpWithDeletePointerActive();
@@ -168,9 +172,9 @@ public interface KeyboardActionListener {
             return false;
         }
         @Override
-        public boolean toggleNumpad(boolean withSliding, boolean forceReturnToAlpha) {
-            return false;
-        }
+        public void toggleLayout(LayoutDirective.Utility layout, int autoCapsFlags, @Nullable RecapitalizeMode recapitalizeMode) {}
+        @Override
+        public void onLongPressAlphaSymbolForNumpad() {}
         @Override
         public void onEndSpaceSwipe() {}
         @Override

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
@@ -13,6 +13,7 @@ import helium314.keyboard.event.HangulEventDecoder
 import helium314.keyboard.event.HapticEvent
 import helium314.keyboard.event.HardwareEventDecoder
 import helium314.keyboard.event.HardwareKeyboardEventDecoder
+import helium314.keyboard.keyboard.internal.LayoutDirective
 import helium314.keyboard.keyboard.internal.keyboard_parser.floris.KeyCode
 import helium314.keyboard.latin.AudioAndHapticFeedbackManager
 import helium314.keyboard.latin.EmojiAltPhysicalKeyDetector
@@ -25,8 +26,9 @@ import helium314.keyboard.latin.common.moveStepsToCharCount
 import helium314.keyboard.latin.define.ProductionFlags
 import helium314.keyboard.latin.inputlogic.InputLogic
 import helium314.keyboard.latin.settings.Settings
-import helium314.keyboard.latin.utils.GestureDataGatheringSettings
 import helium314.keyboard.latin.utils.BackgroundGatheringCache
+import helium314.keyboard.latin.utils.GestureDataGatheringSettings
+import helium314.keyboard.latin.utils.RecapitalizeMode
 import helium314.keyboard.latin.utils.SubtypeSettings
 import helium314.keyboard.latin.utils.prefs
 import kotlin.math.abs
@@ -195,14 +197,20 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
     override fun onHorizontalSpaceSwipe(steps: Int): Boolean = when (Settings.getValues().mSpaceSwipeHorizontal) {
         KeyboardActionListener.SwipeAction.MOVE_CURSOR -> onMoveCursorHorizontally(steps)
         KeyboardActionListener.SwipeAction.SWITCH_LANGUAGE -> onLanguageSlide(steps)
-        KeyboardActionListener.SwipeAction.TOGGLE_NUMPAD -> toggleNumpad(false, false)
+        KeyboardActionListener.SwipeAction.TOGGLE_NUMPAD -> {
+            toggleLayout(LayoutDirective.Utility.NUMPAD, latinIME.currentAutoCapsState, latinIME.currentRecapitalizeState)
+            true
+        }
         else -> false
     }
 
     override fun onVerticalSpaceSwipe(steps: Int): Boolean = when (Settings.getValues().mSpaceSwipeVertical) {
         KeyboardActionListener.SwipeAction.MOVE_CURSOR -> onMoveCursorVertically(steps)
         KeyboardActionListener.SwipeAction.SWITCH_LANGUAGE -> onLanguageSlide(steps)
-        KeyboardActionListener.SwipeAction.TOGGLE_NUMPAD -> toggleNumpad(false, false)
+        KeyboardActionListener.SwipeAction.TOGGLE_NUMPAD -> {
+            toggleLayout(LayoutDirective.Utility.NUMPAD, latinIME.currentAutoCapsState, latinIME.currentRecapitalizeState)
+            true
+        }
         KeyboardActionListener.SwipeAction.HIDE_KEYBOARD -> {
             latinIME.requestHideSelf(0)
             true
@@ -223,14 +231,17 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
         else -> false
     }
 
-    override fun onEndSpaceSwipe(){
+    override fun onEndSpaceSwipe() {
         initialSubtype = null
         subtypeSwitchCount = 0
     }
 
-    override fun toggleNumpad(withSliding: Boolean, forceReturnToAlpha: Boolean): Boolean {
-        keyboardSwitcher.toggleNumpad(withSliding, latinIME.currentAutoCapsState, latinIME.currentRecapitalizeState, forceReturnToAlpha)
-        return true
+    override fun toggleLayout(layout: LayoutDirective.Utility, autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
+        keyboardSwitcher.toggleLayout(layout, autoCapsFlags, recapitalizeMode)
+    }
+
+    override fun onLongPressAlphaSymbolForNumpad() {
+        keyboardSwitcher.onLongPressAlphaSymbolForNumpad()
     }
 
     override fun onMoveDeletePointer(steps: Int) {

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
@@ -36,10 +36,10 @@ import helium314.keyboard.event.Event;
 import helium314.keyboard.keyboard.clipboard.ClipboardHistoryView;
 import helium314.keyboard.keyboard.emoji.EmojiPalettesView;
 import helium314.keyboard.keyboard.internal.KeyboardState;
+import helium314.keyboard.keyboard.internal.LayoutDirective;
 import helium314.keyboard.keyboard.internal.ShiftMode;
 import helium314.keyboard.keyboard.internal.keyboard_parser.EmojiParserKt;
 import helium314.keyboard.latin.CapsMode;
-import helium314.keyboard.latin.utils.FloatingKeyboardUtils;
 import helium314.keyboard.latin.InputView;
 import helium314.keyboard.latin.KeyboardWrapperView;
 import helium314.keyboard.latin.LatinIME;
@@ -51,6 +51,7 @@ import helium314.keyboard.latin.settings.SettingsKt;
 import helium314.keyboard.latin.settings.SettingsValues;
 import helium314.keyboard.latin.suggestions.SuggestionStripView;
 import helium314.keyboard.latin.utils.CapsModeUtils;
+import helium314.keyboard.latin.utils.FloatingKeyboardUtils;
 import helium314.keyboard.latin.utils.FoldableUtils;
 import helium314.keyboard.latin.utils.KtxKt;
 import helium314.keyboard.latin.utils.LanguageOnSpacebarUtils;
@@ -363,12 +364,16 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
     }
 
     @Override
-    public void toggleNumpad(final boolean withSliding, final int autoCapsFlags,
-            @Nullable final RecapitalizeMode recapitalizeMode, final boolean forceReturnToAlpha) {
+    public void toggleLayout(@NonNull LayoutDirective.Utility layout, int autoCapsFlags, @Nullable RecapitalizeMode recapitalizeMode) {
+        mState.toggleLayout(layout, autoCapsFlags, recapitalizeMode);
+    }
+
+    @Override
+    public void onLongPressAlphaSymbolForNumpad() {
         if (DEBUG_ACTION) {
-            Log.d(TAG, "toggleNumpad");
+            Log.d(TAG, "onLongPressAlphaSymbol");
         }
-        mState.toggleNumpad(withSliding, autoCapsFlags, recapitalizeMode, forceReturnToAlpha, true);
+        mState.onLongPressAlphaSymbolForNumpad();
     }
 
     public enum KeyboardSwitchState {

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -1179,9 +1179,8 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
                 return;
             }
         }
-        if (code == KeyCode.SYMBOL_ALPHA && Settings.getValues().mLongPressSymbolsForNumpad) {
-            // toggle numpad with sliding input enabled, forcing return to the alpha layout when done
-            sListener.toggleNumpad(true, true);
+        if (code == KeyCode.SYMBOL_ALPHA) {
+            sListener.onLongPressAlphaSymbolForNumpad();
             return;
         }
 
@@ -1274,6 +1273,13 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         if (mIsInDraggingFinger && (code == KeyCode.SHIFT || key.getPopupKeys() == null)) return;
         if (code == KeyCode.SHIFT && sIsShiftLongPressSuppressed) {
             sIsShiftLongPressSuppressed = false;
+            return;
+        }
+        if (code == KeyCode.SYMBOL_ALPHA
+            && (!Settings.getValues().mLongPressSymbolsForNumpad
+                || mKeyboard.mId.getElement() != KeyboardElement.SYMBOLS
+            )
+        ) {
             return;
         }
 

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -1258,9 +1258,10 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
     }
 
     private void startLongPressTimer(Key key) {
-        // Note that we need to cancel all active long press shift key timers if any whenever we
-        // start a new long press timer for both non-shift and shift keys.
+        // Note that we need to cancel all active long press shift and symbol key timers if
+        // any whenever we start a new long press timer for both non-shift and shift keys.
         sTimerProxy.cancelLongPressShiftKeyTimer();
+        sTimerProxy.cancelLongPressAlphaSymbolKeyTimer();
         if (sInGesture) return;
         if (key == null) return;
         if (!key.isLongPressEnabled()) return;

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -1159,7 +1159,8 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         if (key == null) {
             return;
         }
-        sListener.onLongPressKey(key.getCode());
+        final int code = key.getCode();
+        sListener.onLongPressKey(code);
         if (key.hasNoPanelAutoPopupKey()) {
             cancelKeyTracking();
             final int popupKeyCode = key.getPopupKeys()[0].mCode;
@@ -1168,7 +1169,6 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             sListener.onReleaseKey(popupKeyCode, false);
             return;
         }
-        final int code = key.getCode();
         if (code == KeyCode.LANGUAGE_SWITCH
                 || (code == Constants.CODE_SPACE && key.getPopupKeys() == null && Settings.getValues().mSpaceForLangChange)
         ) {
@@ -1289,16 +1289,19 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         sTimerProxy.startLongPressTimerOf(this, delay);
     }
 
-    private int getLongPressTimeout(final int code) {
-        final int longpressTimeout = Settings.getValues().mKeyLongpressTimeout;
-        if (code == KeyCode.SHIFT || code == KeyCode.SYMBOL_ALPHA) {
-            // We use slightly longer timeout for shift-lock and the numpad long-press.
-            return longpressTimeout * 3 / 2;
-        } else if (mIsInSlidingKeyInput) {
-            // We use longer timeout for sliding finger input started from a modifier key.
-            return longpressTimeout * 3;
-        }
-        return longpressTimeout;
+    private int getLongPressTimeout(int code) {
+        int longpressTimeout = Settings.getValues().mKeyLongpressTimeout;
+        return switch (code) {
+            case Constants.CODE_SPACE, KeyCode.SHIFT, KeyCode.SYMBOL_ALPHA
+                // We use slightly longer timeout for space, shift-lock, and the numpad long-press.
+                -> longpressTimeout * 3 / 2
+            ;
+            default -> mIsInSlidingKeyInput
+                // We use longer timeout for sliding finger input started from a modifier key.
+                ? longpressTimeout * 3
+                : longpressTimeout
+            ;
+        };
     }
 
     private boolean isClearlyInsideKey(final Key key, final int x, final int y) {

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/KeyboardState.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/KeyboardState.kt
@@ -9,6 +9,8 @@ import android.text.TextUtils
 import helium314.keyboard.event.Event
 import helium314.keyboard.keyboard.KeyboardSwitcher
 import helium314.keyboard.keyboard.PointerTracker
+import helium314.keyboard.keyboard.internal.LayoutDirective.Alphabet
+import helium314.keyboard.keyboard.internal.LayoutDirective.Utility
 import helium314.keyboard.keyboard.internal.keyboard_parser.floris.KeyCode
 import helium314.keyboard.latin.common.Constants
 import helium314.keyboard.latin.define.DebugFlags
@@ -34,9 +36,10 @@ class KeyboardState(private val switchActions: SwitchActions) {
         fun setEmojiKeyboard()
         fun setClipboardKeyboard()
         fun setNumpadKeyboard()
-        fun toggleNumpad(withSliding: Boolean, autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?, forceReturnToAlpha: Boolean)
         fun setSymbolsKeyboard()
         fun setSymbolsShiftedKeyboard()
+        fun toggleLayout(layout: Utility, autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?)
+        fun onLongPressAlphaSymbolForNumpad()
 
         /** Request to call back [KeyboardState.onUpdateShiftState]. */
         fun requestUpdatingShiftState(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?)
@@ -58,13 +61,13 @@ class KeyboardState(private val switchActions: SwitchActions) {
     private var shiftKeyState = ModifierKeyState.RELEASED
     private var symbolKeyState = ModifierKeyState.RELEASED
     private var shiftMode = ShiftMode.UNSHIFT
-
-    private var switchState = SwitchState.ALPHA
+    private var prevShiftMode: ShiftMode? = null
+    private var isInShiftSlide = false
+    private var isInLayoutSlide = false
 
     private var mode = Mode.ALPHABET
-    private var modeBeforeNumpad = Mode.ALPHABET // todo: replace with stack logic
-    private var prevShiftMode: ShiftMode? = null
-    private var prevSymbolsKeyboardWasShifted = false // todo: replace with stack logic
+    private val prevLayouts = WeakStack(Mode.entries)
+    private var isInSpaceToAlpha = false
     private var recapitalizeMode: RecapitalizeMode? = null
 
     // For handling double tap.
@@ -93,7 +96,10 @@ class KeyboardState(private val switchActions: SwitchActions) {
         // Reset alphabet shift state.
         shiftMode = ShiftMode.UNSHIFT
         prevShiftMode = null
-        prevSymbolsKeyboardWasShifted = false
+        isInShiftSlide = false
+        isInLayoutSlide = false
+        prevLayouts.wipe()
+        isInSpaceToAlpha = false
         shiftKeyState = ModifierKeyState.RELEASED
         symbolKeyState = ModifierKeyState.RELEASED
         if (savedKeyboardState.isValid) {
@@ -101,7 +107,8 @@ class KeyboardState(private val switchActions: SwitchActions) {
             savedKeyboardState.isValid = false
         } else {
             // Reset keyboard to alphabet mode.
-            setAlphabetKeyboard(ShiftMode.UNSHIFT, autoCapsFlags, recapitalizeMode)
+            loadLayout(Alphabet(ShiftMode.UNSHIFT, autoCapsFlags, recapitalizeMode))
+            switchActions.requestUpdatingShiftState(autoCapsFlags, recapitalizeMode)
         }
         switchActions.setOneHandedModeEnabled(onHandedModeEnabled)
         switchActions.setFloatingKeyboardEnabled(Settings.getValues().mIsFloatingKeyboard)
@@ -120,15 +127,9 @@ class KeyboardState(private val switchActions: SwitchActions) {
         if (DEBUG_EVENT) {
             Log.d(TAG, "onRestoreKeyboardState: saved=$savedKeyboardState ${stateToString(autoCapsFlags, recapitalizeMode)}")
         }
-        when (savedKeyboardState.mode) {
-            Mode.ALPHABET -> setAlphabetKeyboard(savedKeyboardState.shiftMode, autoCapsFlags, recapitalizeMode)
-            Mode.SYMBOLS -> setSymbolsKeyboard()
-            Mode.SYMBOLS_SHIFTED -> setSymbolsShiftedKeyboard()
-            Mode.EMOJI -> setEmojiKeyboard()
-            Mode.CLIPBOARD -> setClipboardKeyboard()
-            // don't overwrite toggle state if reloading from orientation change, etc.
-            Mode.NUMPAD -> setNumpadKeyboard(false, false, false)
-        }
+        // don't save previous layout if reloading from orientation change, etc.
+        prevLayouts.wipe()
+        loadLayout(savedKeyboardState.mode.directive(savedKeyboardState.shiftMode, autoCapsFlags, recapitalizeMode))
     }
 
     private fun setShifted(shiftMode: ShiftMode) {
@@ -142,130 +143,70 @@ class KeyboardState(private val switchActions: SwitchActions) {
         }
     }
 
-    private fun toggleAlphabetAndSymbols(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
+    private fun resetToAlpha(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
         if (DebugFlags.DEBUG_ENABLED) {
-            Log.d(TAG, "toggleAlphabetAndSymbols: ${stateToString(autoCapsFlags, recapitalizeMode)}")
+            Log.d(TAG, "resetToAlpha: ${stateToString(autoCapsFlags, recapitalizeMode)}")
         }
+        prevLayouts.wipe()
         if (mode == Mode.ALPHABET) {
-            if (prevSymbolsKeyboardWasShifted) setSymbolsShiftedKeyboard() else setSymbolsKeyboard()
-            prevSymbolsKeyboardWasShifted = false
-        } else {
-            prevSymbolsKeyboardWasShifted = mode == Mode.SYMBOLS_SHIFTED
-            setAlphabetKeyboard(shiftMode, autoCapsFlags, recapitalizeMode)
-        }
-    }
-
-    // TODO: Remove this method. Come up with a more comprehensive way to reset the keyboard layout
-    //  when a keyboard layout set doesn't get reloaded in LatinIME.onStartInputViewInternal().
-    private fun resetKeyboardStateToAlphabet(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
-        if (DebugFlags.DEBUG_ENABLED) {
-            Log.d(TAG, "resetKeyboardStateToAlphabet: ${stateToString(autoCapsFlags, recapitalizeMode)}")
-        }
-        if (mode == Mode.ALPHABET) return
-
-        prevSymbolsKeyboardWasShifted = mode == Mode.SYMBOLS_SHIFTED
-        setAlphabetKeyboard(shiftMode, autoCapsFlags, recapitalizeMode)
-    }
-
-    private fun toggleShiftInSymbols() {
-        if (mode == Mode.SYMBOLS_SHIFTED) {
-            setSymbolsKeyboard()
-        } else {
-            setSymbolsShiftedKeyboard()
-        }
-    }
-
-    private fun setAlphabetKeyboard(shiftMode: ShiftMode, autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
-        if (DebugFlags.DEBUG_ENABLED) {
-            Log.d(TAG, "setAlphabetKeyboard: ${stateToString(autoCapsFlags, recapitalizeMode)}")
-        }
-
-        switchActions.setAlphabetKeyboard(shiftMode)
-        mode = Mode.ALPHABET
-        this.recapitalizeMode = null
-        switchState = SwitchState.ALPHA
-        if (shiftMode == ShiftMode.UNSHIFT || shiftMode == ShiftMode.AUTOMATIC) {
-            switchActions.requestUpdatingShiftState(autoCapsFlags, recapitalizeMode)
-        }
-    }
-
-    private fun setSymbolsKeyboard() {
-        if (DebugFlags.DEBUG_ENABLED) {
-            Log.d(TAG, "setSymbolsKeyboard")
-        }
-        switchActions.setSymbolsKeyboard()
-        mode = Mode.SYMBOLS
-        recapitalizeMode = null
-        switchState = SwitchState.SYMBOL_BEGIN
-    }
-
-    private fun setSymbolsShiftedKeyboard() {
-        if (DebugFlags.DEBUG_ENABLED) {
-            Log.d(TAG, "setSymbolsShiftedKeyboard")
-        }
-        switchActions.setSymbolsShiftedKeyboard()
-        mode = Mode.SYMBOLS_SHIFTED
-        recapitalizeMode = null
-        switchState = SwitchState.SYMBOL_BEGIN
-    }
-
-    private fun setEmojiKeyboard() {
-        if (DebugFlags.DEBUG_ENABLED) {
-            Log.d(TAG, "setEmojiKeyboard")
-        }
-        switchActions.setEmojiKeyboard()
-        mode = Mode.EMOJI
-        recapitalizeMode = null
-    }
-
-    private fun setClipboardKeyboard() {
-        if (DebugFlags.DEBUG_ENABLED) {
-            Log.d(TAG, "setClipboardKeyboard")
-        }
-        switchActions.setClipboardKeyboard()
-        mode = Mode.CLIPBOARD
-        recapitalizeMode = null
-    }
-
-    private fun setNumpadKeyboard(withSliding: Boolean, forceReturnToAlpha: Boolean, rememberState: Boolean) {
-        if (DebugFlags.DEBUG_ENABLED) {
-            Log.d(TAG, "setNumpadKeyboard")
-        }
-        if (rememberState) {
-            // When d-pad is added, "selection mode" may need to be remembered if not a global state
-            modeBeforeNumpad = if (forceReturnToAlpha) Mode.ALPHABET else mode
-        }
-        mode = Mode.NUMPAD
-        recapitalizeMode = null
-        switchActions.setNumpadKeyboard()
-        switchState = if (withSliding) SwitchState.MOMENTARY_TO_NUMPAD else SwitchState.NUMPAD_BEGIN
-    }
-
-    fun toggleNumpad(
-        withSliding: Boolean,
-        autoCapsFlags: Int,
-        recapitalizeMode: RecapitalizeMode?,
-        forceReturnToAlpha: Boolean,
-        rememberState: Boolean
-    ) {
-        if (DebugFlags.DEBUG_ENABLED) {
-            Log.d(TAG, "toggleNumpad")
-        }
-        if (mode != Mode.NUMPAD) {
-            setNumpadKeyboard(withSliding, forceReturnToAlpha, rememberState)
             return
         }
-        if (modeBeforeNumpad == Mode.ALPHABET || forceReturnToAlpha) {
-            setAlphabetKeyboard(shiftMode, autoCapsFlags, recapitalizeMode)
-        } else when (modeBeforeNumpad) {
-            Mode.ALPHABET -> {}
-            Mode.SYMBOLS -> setSymbolsKeyboard()
-            Mode.SYMBOLS_SHIFTED -> setSymbolsShiftedKeyboard()
-            Mode.EMOJI -> setEmojiKeyboard()
-            Mode.CLIPBOARD -> setClipboardKeyboard()
-            Mode.NUMPAD -> {}
+        loadLayout(Alphabet(shiftMode, autoCapsFlags, recapitalizeMode))
+    }
+
+    private fun slideInto(layout: LayoutDirective) {
+        isInLayoutSlide = true
+        setLayout(layout)
+    }
+
+    private fun setLayout(layout: LayoutDirective) {
+        prevLayouts.push(mode)
+        loadLayout(layout)
+    }
+
+    private fun loadLayout(layout: LayoutDirective) {
+        if (DebugFlags.DEBUG_ENABLED) {
+            Log.d(TAG, "loadLayout($layout)")
         }
-        if (withSliding) switchState = SwitchState.MOMENTARY_FROM_NUMPAD
+        when (layout) {
+            is Alphabet -> switchActions.setAlphabetKeyboard(layout.shiftMode)
+            Utility.SYMBOLS -> switchActions.setSymbolsKeyboard()
+            Utility.SYMBOLS_SHIFTED -> switchActions.setSymbolsShiftedKeyboard()
+            Utility.EMOJI -> switchActions.setEmojiKeyboard()
+            Utility.CLIPBOARD -> switchActions.setClipboardKeyboard()
+            Utility.NUMPAD -> switchActions.setNumpadKeyboard()
+        }
+        mode = layout.mode()
+        recapitalizeMode = null
+        isInSpaceToAlpha = false
+        if (layout is Alphabet && layout.shiftMode == ShiftMode.AUTOMATIC) {
+            switchActions.requestUpdatingShiftState(layout.autoCapsFlags, layout.recapitalizeMode)
+        }
+    }
+
+    fun onLongPressAlphaSymbolForNumpad() {
+        // We want sliding input to return to the original layout, so
+        // don't remember the layout shown momentarily when holding
+        loadLayout(Utility.NUMPAD)
+    }
+
+    fun toggleLayout(layout: Utility, autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
+        if (DebugFlags.DEBUG_ENABLED) {
+            Log.d(TAG, "toggleLayout(layout=$layout, autoCapsFlags=${CapsModeUtils.flagsToString(autoCapsFlags)}, recapitalizeMode=$recapitalizeMode)")
+        }
+        if (mode == layout.mode()) {
+            loadPreviousLayout(autoCapsFlags, recapitalizeMode)
+        } else {
+            setLayout(layout)
+        }
+        if (isInLayoutSlide) {
+            prevLayouts.pop()
+            isInLayoutSlide = false
+        }
+    }
+
+    private fun loadPreviousLayout(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
+        loadLayout(prevLayouts.pop().directive(shiftMode, autoCapsFlags, recapitalizeMode))
     }
 
     fun onPressKey(code: Int, pointerCount: Int, autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
@@ -314,49 +255,34 @@ class KeyboardState(private val switchActions: SwitchActions) {
                     ShiftMode.LOCKED
                 }
             )
-            KeyCode.SYMBOL_ALPHA -> onReleaseAlphaSymbol(withSliding, autoCapsFlags, recapitalizeMode)
+            KeyCode.SYMBOL_ALPHA -> {
+                if (symbolKeyState == ModifierKeyState.CHORDING) {
+                    // Switch back to the previous keyboard mode if the user chords the mode change key and
+                    // another key, then releases the mode change key.
+                    loadPreviousLayout(autoCapsFlags, recapitalizeMode)
+                }
+                if (withSliding) {
+                    isInLayoutSlide = true
+                }
+                symbolKeyState = ModifierKeyState.RELEASED
+            }
             // if no sliding, switching is instead handled by onEvent()
             // to accommodate toolbar keys and prevent double-loads.
-            KeyCode.SYMBOL       -> if (withSliding) slideIntoSymbol()
-            KeyCode.ALPHA        -> if (withSliding) slideIntoAlpha(autoCapsFlags, recapitalizeMode)
-            KeyCode.NUMPAD       -> if (withSliding) setNumpadKeyboard(true, modeBeforeNumpad == Mode.CLIPBOARD, true)
+            KeyCode.SYMBOL       -> if (withSliding) slideInto(Utility.SYMBOLS)
+            KeyCode.ALPHA        -> if (withSliding) slideInto(Alphabet(shiftMode, autoCapsFlags, recapitalizeMode))
+            KeyCode.NUMPAD       -> if (withSliding) slideInto(Utility.NUMPAD)
         }
     }
 
     private fun onPressAlphaSymbol(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
-        toggleAlphabetAndSymbols(autoCapsFlags, recapitalizeMode)
+        setLayout(
+            if (mode == Mode.ALPHABET) {
+                Utility.SYMBOLS
+            } else {
+                Alphabet(shiftMode, autoCapsFlags, recapitalizeMode)
+            }
+        )
         symbolKeyState = ModifierKeyState.PRESSING
-        switchState = SwitchState.MOMENTARY_ALPHA_AND_SYMBOL
-    }
-
-    private fun onReleaseAlphaSymbol(withSliding: Boolean, autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
-        if (symbolKeyState == ModifierKeyState.CHORDING) {
-            // Switch back to the previous keyboard mode if the user chords the mode change key and
-            // another key, then releases the mode change key.
-            toggleAlphabetAndSymbols(autoCapsFlags, recapitalizeMode)
-        } else if (!withSliding) {
-            // If the mode change key is being released without sliding, we should forget the
-            // previous symbols keyboard shift state and simply switch back to symbols layout
-            // (never symbols shifted) next time the mode gets changed to symbols layout.
-            prevSymbolsKeyboardWasShifted = false
-        }
-        symbolKeyState = ModifierKeyState.RELEASED
-    }
-
-    private fun slideIntoSymbol() {
-        val oldMode = mode
-        setSymbolsKeyboard()
-        if (oldMode == Mode.NUMPAD) {
-            switchState = SwitchState.MOMENTARY_FROM_NUMPAD
-        }
-    }
-
-    private fun slideIntoAlpha(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
-        val oldMode = mode
-        setAlphabetKeyboard(shiftMode, autoCapsFlags, recapitalizeMode)
-        if (oldMode == Mode.NUMPAD) {
-            switchState = SwitchState.MOMENTARY_FROM_NUMPAD
-        }
     }
 
     fun onUpdateShiftState(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
@@ -373,7 +299,7 @@ class KeyboardState(private val switchActions: SwitchActions) {
         if (DEBUG_EVENT) {
             Log.d(TAG, "onResetKeyboardStateToAlphabet: ${stateToString(autoCapsFlags, recapitalizeMode)}")
         }
-        resetKeyboardStateToAlphabet(autoCapsFlags, recapitalizeMode)
+        resetToAlpha(autoCapsFlags, recapitalizeMode)
     }
 
     private fun updateAlphabetShiftState(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) {
@@ -395,7 +321,10 @@ class KeyboardState(private val switchActions: SwitchActions) {
         }
         if (shiftMode != ShiftMode.LOCKED) {
             // todo: it's annoying when this happens in manual shift, but in order to block it we would
-            //  need to know whether this is an update for typing a letter in shift or moving the caret
+            //  need to know whether this is an update for typing a letter that pops manual shift or
+            //  moving the caret or whatever other cases. would also be nice for the space bar (and
+            //  maybe other non-letter characters?) to not pop manual shift, which is especially
+            //  confusing when space-to-alpha activates on the symbol or numpad layouts.
             setShifted(
                 if (autoCapsFlags != Constants.TextUtils.CAP_MODE_OFF) {
                     ShiftMode.AUTOMATIC
@@ -415,14 +344,18 @@ class KeyboardState(private val switchActions: SwitchActions) {
                 // todo: this isn't detected before the first recapitalization
                 return
             }
-            if (mode == Mode.SYMBOLS || mode == Mode.SYMBOLS_SHIFTED) {
-                // In symbol mode, just toggle symbol and symbol popup keyboard.
-                toggleShiftInSymbols()
-                switchState = SwitchState.MOMENTARY_SYMBOL_AND_MORE
-                return
-            }
-            if (mode != Mode.ALPHABET) {
-                return
+            // In symbols mode, the shift key is actually the more-symbols toggle
+            when (mode) {
+                Mode.ALPHABET -> {}
+                Mode.SYMBOLS -> {
+                    setLayout(Utility.SYMBOLS_SHIFTED)
+                    return
+                }
+                Mode.SYMBOLS_SHIFTED -> {
+                    setLayout(Utility.SYMBOLS)
+                    return
+                }
+                else -> return
             }
             isInDoubleTapShiftKey = switchActions.popDoubleTapShiftKeyTimer()
             if (isInDoubleTapShiftKey) {
@@ -456,8 +389,12 @@ class KeyboardState(private val switchActions: SwitchActions) {
                 return
             }
             if (mode == Mode.SYMBOLS || mode == Mode.SYMBOLS_SHIFTED) {
+                // In symbols mode, the shift key is actually the more-symbols toggle
                 if (shiftKeyState == ModifierKeyState.CHORDING) {
-                    toggleShiftInSymbols()
+                    loadPreviousLayout(autoCapsFlags, recapitalizeMode)
+                }
+                if (withSliding) {
+                    isInLayoutSlide = true
                 }
                 return
             }
@@ -481,7 +418,7 @@ class KeyboardState(private val switchActions: SwitchActions) {
                 return
             }
             if (withSliding) {
-                switchState = SwitchState.MOMENTARY_ALPHA_SHIFT
+                isInShiftSlide = true
             }
         }
         inner()
@@ -502,18 +439,13 @@ class KeyboardState(private val switchActions: SwitchActions) {
         if (DEBUG_EVENT) {
             Log.d(TAG, "onFinishSlidingInput: " + stateToString(autoCapsFlags, recapitalizeMode))
         }
-        // Switch back to the previous keyboard mode if the user didn't enter the numpad.
-        if (mode != Mode.NUMPAD) when (switchState) {
-            SwitchState.MOMENTARY_ALPHA_AND_SYMBOL -> toggleAlphabetAndSymbols(autoCapsFlags, recapitalizeMode)
-            SwitchState.MOMENTARY_SYMBOL_AND_MORE  -> toggleShiftInSymbols()
-            SwitchState.MOMENTARY_ALPHA_SHIFT      -> {
-                restorePreviousShiftMode()
-                prevShiftMode = null
-            }
-            SwitchState.MOMENTARY_FROM_NUMPAD      -> setNumpadKeyboard(false, false, false)
-            else                                   -> {}
-        } else if (switchState == SwitchState.MOMENTARY_TO_NUMPAD) {
-            toggleNumpad(false, autoCapsFlags, recapitalizeMode, false, false)
+        if (isInShiftSlide) {
+            isInShiftSlide = false
+            restorePreviousShiftMode()
+            prevShiftMode = null
+        } else if (isInLayoutSlide) {
+            isInLayoutSlide = false
+            loadPreviousLayout(autoCapsFlags, recapitalizeMode)
         }
     }
 
@@ -523,58 +455,28 @@ class KeyboardState(private val switchActions: SwitchActions) {
             Log.d(TAG, "onEvent: code=${Constants.printableCode(code)} ${stateToString(autoCapsFlags, recapitalizeMode)}")
         }
 
-        when (switchState) {
-            SwitchState.SYMBOL ->
-                // Switch back to alpha keyboard mode if user types one or more non-space/enter
-                // characters followed by a space/enter.
-                if (isSpaceOrEnter(code) && Settings.getValues().mAlphaAfterSymbolAndSpace) {
-                    toggleAlphabetAndSymbols(autoCapsFlags, recapitalizeMode)
-                    prevSymbolsKeyboardWasShifted = false
+        if (mode in Settings.getValues().mAlphaAfterSpace) {
+            if (isSpaceOrEnter(code)) {
+                if (isInSpaceToAlpha) {
+                    resetToAlpha(autoCapsFlags, recapitalizeMode)
                 }
-            SwitchState.SYMBOL_BEGIN ->
-                if (mode == Mode.EMOJI || mode == Mode.CLIPBOARD) {
-                    // When in the Emoji keyboard or clipboard one, we don't want to switch back to the main layout even
-                    // after the user hits an emoji letter followed by an enter or a space.
-                } else if (!isSpaceOrEnter(code) && (Constants.isLetterCode(code) || code == KeyCode.MULTIPLE_CODE_POINTS)) {
-                    switchState = SwitchState.SYMBOL
-                }
-            SwitchState.NUMPAD ->
-                // Switch back to alpha keyboard mode if user types one or more non-space/enter
-                // characters followed by a space/enter.
-                if (isSpaceOrEnter(code) && Settings.getValues().mAlphaAfterNumpadAndSpace) {
-                    toggleNumpad(false, autoCapsFlags, recapitalizeMode, true, false)
-                }
-            SwitchState.NUMPAD_BEGIN ->
-                if (!isSpaceOrEnter(code)) {
-                    switchState = SwitchState.NUMPAD
-                }
-            SwitchState.MOMENTARY_ALPHA_AND_SYMBOL ->
-                if (code == KeyCode.SYMBOL_ALPHA) {
-                    // Detected only the mode change key has been pressed, and then released.
-                    switchState = if (mode == Mode.ALPHABET) SwitchState.ALPHA else SwitchState.SYMBOL_BEGIN
-                }
-            SwitchState.MOMENTARY_SYMBOL_AND_MORE ->
-                if (code == KeyCode.SHIFT) {
-                    // Detected only the shift key has been pressed on symbol layout, and then released.
-                    switchState = SwitchState.SYMBOL_BEGIN
-                } else if (isSpaceOrEnter(code)) {
-                    // Switch back to alpha keyboard mode if user types one or more non-space/enter characters followed by a space/enter.
-                    toggleAlphabetAndSymbols(autoCapsFlags, recapitalizeMode)
-                    prevSymbolsKeyboardWasShifted = false
-                }
-            else -> {}
+            } else if (Constants.isLetterCode(code) || code == KeyCode.MULTIPLE_CODE_POINTS) {
+                isInSpaceToAlpha = true
+            }
         }
 
         if (Constants.isLetterCode(code)) {
             // If the code is a letter, update keyboard shift state.
             updateAlphabetShiftState(autoCapsFlags, recapitalizeMode)
         } else when (code) {
-            KeyCode.EMOJI -> setEmojiKeyboard()
-            KeyCode.ALPHA -> setAlphabetKeyboard(shiftMode, autoCapsFlags, recapitalizeMode)
+            KeyCode.EMOJI -> toggleLayout(Utility.EMOJI, autoCapsFlags, recapitalizeMode)
+            KeyCode.ALPHA -> resetToAlpha(autoCapsFlags, recapitalizeMode)
             // Note: Printing clipboard content is handled in InputLogic.handleFunctionalEvent
-            KeyCode.CLIPBOARD -> if (Settings.getValues().mClipboardHistoryEnabled) setClipboardKeyboard()
-            KeyCode.NUMPAD -> toggleNumpad(false, autoCapsFlags, recapitalizeMode, false, true)
-            KeyCode.SYMBOL -> setSymbolsKeyboard()
+            KeyCode.CLIPBOARD -> if (Settings.getValues().mClipboardHistoryEnabled) {
+                toggleLayout(Utility.CLIPBOARD, autoCapsFlags, recapitalizeMode)
+            }
+            KeyCode.NUMPAD -> toggleLayout(Utility.NUMPAD, autoCapsFlags, recapitalizeMode)
+            KeyCode.SYMBOL -> toggleLayout(Utility.SYMBOLS, autoCapsFlags, recapitalizeMode)
             KeyCode.TOGGLE_ONE_HANDED_MODE -> switchActions.setOneHandedModeEnabled(!Settings.getValues().mOneHandedModeEnabled)
             KeyCode.SWITCH_ONE_HANDED_MODE -> switchActions.switchOneHandedMode()
             KeyCode.TOGGLE_FLOATING_WINDOW -> {
@@ -589,32 +491,30 @@ class KeyboardState(private val switchActions: SwitchActions) {
             Mode.ALPHABET -> shiftMode.toString()
             else -> mode.toString()
         }
-        return "[keyboard=$keyboard shift=$shiftKeyState symbol=$symbolKeyState switch=$switchState]"
+        return "[keyboard=$keyboard shift=$shiftKeyState symbol=$symbolKeyState]"
     }
 
     private fun stateToString(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?) =
         "$this autoCapsFlags=${CapsModeUtils.flagsToString(autoCapsFlags)} recapitalizeMode=$recapitalizeMode"
 
-    private enum class SwitchState {
-        ALPHA,
-        SYMBOL,
-        SYMBOL_BEGIN,
-        NUMPAD,
-        NUMPAD_BEGIN,
-        MOMENTARY_ALPHA_AND_SYMBOL,
-        MOMENTARY_SYMBOL_AND_MORE,
-        MOMENTARY_ALPHA_SHIFT,
-        MOMENTARY_TO_NUMPAD,
-        MOMENTARY_FROM_NUMPAD,
-    }
-
-    private enum class Mode {
+    enum class Mode {
         ALPHABET,
         SYMBOLS,
         SYMBOLS_SHIFTED,
         EMOJI,
         CLIPBOARD,
         NUMPAD,
+    ;
+        fun directive(shiftMode: ShiftMode, autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?): LayoutDirective {
+            return when (this) {
+                ALPHABET -> Alphabet(shiftMode, autoCapsFlags, recapitalizeMode)
+                SYMBOLS -> Utility.SYMBOLS
+                SYMBOLS_SHIFTED -> Utility.SYMBOLS_SHIFTED
+                EMOJI -> Utility.EMOJI
+                CLIPBOARD -> Utility.CLIPBOARD
+                NUMPAD -> Utility.NUMPAD
+            }
+        }
     }
 
     companion object {

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/LayoutDirective.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/LayoutDirective.java
@@ -1,0 +1,49 @@
+package helium314.keyboard.keyboard.internal;
+
+import androidx.annotation.Nullable;
+
+import helium314.keyboard.latin.utils.CapsModeUtils;
+import helium314.keyboard.latin.utils.RecapitalizeMode;
+
+public sealed interface LayoutDirective {
+    KeyboardState.Mode mode();
+
+    record Alphabet(
+        ShiftMode shiftMode,
+        int autoCapsFlags,
+        @Nullable RecapitalizeMode recapitalizeMode
+    ) implements LayoutDirective {
+        @Override
+        public KeyboardState.Mode mode() {
+            return KeyboardState.Mode.ALPHABET;
+        }
+
+        @Override
+        public String toString() {
+            return "Alphabet{shiftMode=" + shiftMode
+                 + ", autoCapsFlags=" + CapsModeUtils.flagsToString(autoCapsFlags)
+                 + ", recapitalizeMode=" + recapitalizeMode
+                 + '}'
+            ;
+        }
+    }
+
+    enum Utility implements LayoutDirective {
+        SYMBOLS(KeyboardState.Mode.SYMBOLS),
+        SYMBOLS_SHIFTED(KeyboardState.Mode.SYMBOLS_SHIFTED),
+        EMOJI(KeyboardState.Mode.EMOJI),
+        CLIPBOARD(KeyboardState.Mode.CLIPBOARD),
+        NUMPAD(KeyboardState.Mode.NUMPAD),
+    ;
+        private final KeyboardState.Mode mMode;
+
+        Utility(KeyboardState.Mode mode) {
+            mMode = mode;
+        }
+
+        @Override
+        public KeyboardState.Mode mode() {
+            return mMode;
+        }
+    }
+}

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/LayoutDirective.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/LayoutDirective.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-only
 package helium314.keyboard.keyboard.internal;
 
 import androidx.annotation.Nullable;

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/TimerHandler.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/TimerHandler.java
@@ -24,10 +24,11 @@ public final class TimerHandler extends LeakGuardHandlerWrapper<DrawingProxy>
     private static final int MSG_REPEAT_KEY = 1;
     private static final int MSG_LONGPRESS_KEY = 2;
     private static final int MSG_LONGPRESS_SHIFT_KEY = 3;
-    private static final int MSG_DOUBLE_TAP_SHIFT_KEY = 4;
-    private static final int MSG_UPDATE_BATCH_INPUT = 5;
-    private static final int MSG_DISMISS_KEY_PREVIEW = 6;
-    private static final int MSG_DISMISS_GESTURE_FLOATING_PREVIEW_TEXT = 7;
+    private static final int MSG_LONGPRESS_ALPHA_SYMBOL_KEY = 4;
+    private static final int MSG_DOUBLE_TAP_SHIFT_KEY = 5;
+    private static final int MSG_UPDATE_BATCH_INPUT = 6;
+    private static final int MSG_DISMISS_KEY_PREVIEW = 7;
+    private static final int MSG_DISMISS_GESTURE_FLOATING_PREVIEW_TEXT = 8;
 
     private final int mIgnoreAltCodeKeyTimeout;
     private final int mGestureRecognitionUpdateTime;
@@ -53,7 +54,7 @@ public final class TimerHandler extends LeakGuardHandlerWrapper<DrawingProxy>
             PointerTracker tracker1 = (PointerTracker)msg.obj;
             tracker1.onKeyRepeat(msg.arg1 /* code */, msg.arg2 /* repeatCount */);
         }
-        case MSG_LONGPRESS_KEY, MSG_LONGPRESS_SHIFT_KEY -> {
+        case MSG_LONGPRESS_KEY, MSG_LONGPRESS_SHIFT_KEY, MSG_LONGPRESS_ALPHA_SYMBOL_KEY -> {
             cancelLongPressTimers();
             PointerTracker tracker2 = (PointerTracker)msg.obj;
             tracker2.onLongPressed();
@@ -104,8 +105,11 @@ public final class TimerHandler extends LeakGuardHandlerWrapper<DrawingProxy>
         }
         // Use a separate message id for long pressing shift key, because long press shift key
         // timers should be canceled when other key is pressed.
-        int messageId = (key.getCode() == KeyCode.SHIFT)
-                ? MSG_LONGPRESS_SHIFT_KEY : MSG_LONGPRESS_KEY;
+        int messageId = switch (key.getCode()) {
+            case KeyCode.SHIFT -> MSG_LONGPRESS_SHIFT_KEY;
+            case KeyCode.SYMBOL_ALPHA -> MSG_LONGPRESS_ALPHA_SYMBOL_KEY;
+            default -> MSG_LONGPRESS_KEY;
+        };
         sendMessageDelayed(obtainMessage(messageId, tracker), delay);
     }
 
@@ -113,6 +117,7 @@ public final class TimerHandler extends LeakGuardHandlerWrapper<DrawingProxy>
     public void cancelLongPressTimersOf(@NonNull PointerTracker tracker) {
         removeMessages(MSG_LONGPRESS_KEY, tracker);
         removeMessages(MSG_LONGPRESS_SHIFT_KEY, tracker);
+        removeMessages(MSG_LONGPRESS_ALPHA_SYMBOL_KEY, tracker);
     }
 
     @Override
@@ -120,9 +125,15 @@ public final class TimerHandler extends LeakGuardHandlerWrapper<DrawingProxy>
         removeMessages(MSG_LONGPRESS_SHIFT_KEY);
     }
 
+    @Override
+    public void cancelLongPressAlphaSymbolKeyTimer() {
+        removeMessages(MSG_LONGPRESS_ALPHA_SYMBOL_KEY);
+    }
+
     public void cancelLongPressTimers() {
         removeMessages(MSG_LONGPRESS_KEY);
         removeMessages(MSG_LONGPRESS_SHIFT_KEY);
+        removeMessages(MSG_LONGPRESS_ALPHA_SYMBOL_KEY);
     }
 
     @Override

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/TimerProxy.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/TimerProxy.java
@@ -53,6 +53,11 @@ public interface TimerProxy {
     void cancelLongPressShiftKeyTimer();
 
     /**
+     * Cancel a timer for detecting a long pressed alpha/symbol key.
+     */
+    void cancelLongPressAlphaSymbolKeyTimer();
+
+    /**
      * Cancel timers for detecting repeated key press, long pressed key, and long pressed shift key.
      * @param tracker the {@link PointerTracker} that starts timers to be canceled.
      */
@@ -105,6 +110,8 @@ public interface TimerProxy {
         public void cancelLongPressTimersOf(@NonNull PointerTracker tracker) {}
         @Override
         public void cancelLongPressShiftKeyTimer() {}
+        @Override
+        public void cancelLongPressAlphaSymbolKeyTimer() {}
         @Override
         public void cancelKeyTimersOf(@NonNull PointerTracker tracker) {}
         @Override

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/WeakStack.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/WeakStack.java
@@ -1,0 +1,49 @@
+package helium314.keyboard.keyboard.internal;
+
+import kotlin.enums.EnumEntries;
+
+/// This "weak stack" struct works by packing enum ordinals by half-bytes in a
+/// 64-bit integer. Thus, it is not compatible with enums of more than 2⁴ = 16
+/// entries.
+///
+/// Bitwise operations are performed on these half-bytes to create stack-like
+/// logic. Because they are stored in a 64-bit integer, the stack has a capacity
+/// of 16. When entries are added in excess of this capacity, the oldest entry
+/// is forgotten.
+///
+/// Conversely, the stack has no concept of "item count". Instead, when [#pop()]
+/// is called in excess of the entries that were pushed and remembered, the
+/// enum's first entry is returned as a fallback value. Thus, the order of
+/// constants in the enum definition is significant.
+///
+/// This struct is intended for use where exact recall is not critical and
+/// there's a reasonable default to fall back to when entries are forgotten or
+/// absent. This provides a very efficient short-term memory that doesn't crash
+/// on over or underflow.
+final class WeakStack<E extends Enum<E>> {
+    private final EnumEntries<E> entries;
+    private long stack = 0x0;
+
+    WeakStack(EnumEntries<E> entries) {
+        if (entries.size() > 0x10) {
+            throw new IllegalArgumentException("Enum is too large");
+        } // we can be certain the ordinals will fit into half-bytes
+
+        this.entries = entries;
+    }
+
+    public void push(E e) {
+        stack <<= 0x4;
+        stack |= e.ordinal();
+    }
+
+    public E pop() {
+        var ord = (int) (stack & 0xF);
+        stack >>>= 0x4;
+        return entries.get(ord);
+    }
+
+    public void wipe() {
+        stack = 0x0;
+    }
+}

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/WeakStack.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/WeakStack.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-only
 package helium314.keyboard.keyboard.internal;
 
 import kotlin.enums.EnumEntries;

--- a/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
@@ -22,6 +22,7 @@ import helium314.keyboard.compat.ConfigurationCompatKt;
 import helium314.keyboard.compat.IsLockedCompatKt;
 import helium314.keyboard.keyboard.KeyboardActionListener;
 import helium314.keyboard.keyboard.KeyboardTheme;
+import helium314.keyboard.keyboard.internal.KeyboardState;
 import helium314.keyboard.keyboard.internal.keyboard_parser.LocaleKeyboardInfos;
 import helium314.keyboard.latin.InputAttributes;
 import helium314.keyboard.latin.PunctuationSuggestions;
@@ -37,6 +38,7 @@ import helium314.keyboard.latin.utils.SubtypeSettings;
 import helium314.keyboard.latin.utils.SubtypeUtilsKt;
 import helium314.keyboard.latin.utils.ToolbarMode;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 
@@ -132,8 +134,7 @@ public class SettingsValues {
     public final boolean mAutoHideToolbar;
     public final boolean mAlphaAfterEmojiInEmojiView;
     public final boolean mAlphaAfterClipHistoryEntry;
-    public final boolean mAlphaAfterSymbolAndSpace;
-    public final boolean mAlphaAfterNumpadAndSpace;
+    public final EnumSet<KeyboardState.Mode> mAlphaAfterSpace = EnumSet.noneOf(KeyboardState.Mode.class);
     public final boolean mRemoveRedundantPopups;
     public final String mSpaceBarText;
     public final float mFontSizeMultiplier;
@@ -321,8 +322,13 @@ public class SettingsValues {
         mAutoHideToolbar = mSuggestionsEnabled && prefs.getBoolean(Settings.PREF_AUTO_HIDE_TOOLBAR, Defaults.PREF_AUTO_HIDE_TOOLBAR);
         mAlphaAfterEmojiInEmojiView = prefs.getBoolean(Settings.PREF_ABC_AFTER_EMOJI, Defaults.PREF_ABC_AFTER_EMOJI);
         mAlphaAfterClipHistoryEntry = prefs.getBoolean(Settings.PREF_ABC_AFTER_CLIP, Defaults.PREF_ABC_AFTER_CLIP);
-        mAlphaAfterSymbolAndSpace = prefs.getBoolean(Settings.PREF_ABC_AFTER_SYMBOL_SPACE, Defaults.PREF_ABC_AFTER_SYMBOL_SPACE);
-        mAlphaAfterNumpadAndSpace = prefs.getBoolean(Settings.PREF_ABC_AFTER_NUMPAD_SPACE, Defaults.PREF_ABC_AFTER_NUMPAD_SPACE);
+        if (prefs.getBoolean(Settings.PREF_ABC_AFTER_SYMBOL_SPACE, Defaults.PREF_ABC_AFTER_SYMBOL_SPACE)) {
+            mAlphaAfterSpace.add(KeyboardState.Mode.SYMBOLS);
+            mAlphaAfterSpace.add(KeyboardState.Mode.SYMBOLS_SHIFTED);
+        }
+        if (prefs.getBoolean(Settings.PREF_ABC_AFTER_NUMPAD_SPACE, Defaults.PREF_ABC_AFTER_NUMPAD_SPACE)) {
+            mAlphaAfterSpace.add(KeyboardState.Mode.NUMPAD);
+        }
         mRemoveRedundantPopups = prefs.getBoolean(Settings.PREF_REMOVE_REDUNDANT_POPUPS, Defaults.PREF_REMOVE_REDUNDANT_POPUPS);
         mSpaceBarText = prefs.getString(Settings.PREF_SPACE_BAR_TEXT, Defaults.PREF_SPACE_BAR_TEXT);
         mFontSizeMultiplier = prefs.getFloat(Settings.PREF_FONT_SCALE, Defaults.PREF_FONT_SCALE);

--- a/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
@@ -73,7 +73,7 @@ fun getCodeForToolbarKey(key: ToolbarKey) = Settings.getInstance().getCustomTool
     INCOGNITO -> KeyCode.TOGGLE_INCOGNITO_MODE
     AUTOCORRECT -> KeyCode.TOGGLE_AUTOCORRECT
     CLEAR_CLIPBOARD -> KeyCode.CLIPBOARD_CLEAR_HISTORY
-    CLOSE_HISTORY -> KeyCode.ALPHA
+    CLOSE_HISTORY -> KeyCode.CLIPBOARD
     EMOJI -> KeyCode.EMOJI
     LEFT -> KeyCode.ARROW_LEFT
     RIGHT -> KeyCode.ARROW_RIGHT


### PR DESCRIPTION
Closes #2250. This cleanup patch further builds sanity in the KeyboardState class. Layout switching and management is now both much simpler and more versatile. If I've done my job right, all my old "forceReturnToAlpha" garbage is gone for good. The D-pad is only one step away!

I've deviated from a lot (most?) of what I said in the issue post and comments. I did not attempt to make the non-instant layout keys instant this time around, turns out that's a rather complex goal. We should still aim for that in the future, things like chording with the numpad key should be allowed. I also called out the "alpha-symbol" key and said it should be removed. While it is a weird concept on its face, I now have no plans to deprecate and alias it or anything like that. Doing so would actually be more technically complex than just keeping it how it is, and the cleanup has made it much easier to understand. Things like its place in the functional keys layout, the special safety behavior of the standalone alpha key, and the numpad long press make replacing it with anything else pointless. Same applies for the "shift is actually symbol shift" weirdness. Weird, but not worth changing.

Layout toggling and management is now handled centrally with a pseudo-stack data structure. You can read the `WeakStack` javadoc to get an idea of how this "short term memory" works. TLDR, I made this be specialized class to balance aggressively defensive memory & runtime safety with the practical needs of the program. It's extremely rare for the layout stack to contain more than 16 entries—I don't even know what tap combinations would accomplish this—so the "forget and default" behavior is acceptable. In return we get constant time, constant space, and never any overflow or underflow crashes. The fallback value yielded when the layout stack is "empty" is the alphabet layout.

Here's the behavior changelist:
- Generally, "toggle X layout" actions are more sane. Things like the numpad space swipe (as before), numpad, clipboard, and close clipboard toolbar keys, etc. will toggle back to the previous layout when pressed in their respective layouts. Rather than forcing all the way back to alpha. The memory for this is centralized, rather than having a manic scramble of `SwitchState`s and `modeBeforeNumpad`s. `SwitchState` is gone btw, don't need it anymore.
- I don't even know whether chording worked when doing the symbols -> numpad long press as looking at the old code wouldn't tell me much, but I have tested that both chording and sliding work for it and that they return to the starting layout (alpha) when done. The logic for this is much more sane.
- Fixed a bug where the long press haptics trigger on the symbols key in phone keys mode, or when the numpad long press is supposed to be disabled.
- "Obnoxious rider": we once had a longer long press timer for the space bar since it's a bigger key, but this went away at some point. Wouldn't be surprised if this was a side effect of something I did a while ago or something. Anyways, I've restored it here as a 1.5x multiplier since I'm too lazy to open a separate PR for it. Hope this is okay with you.