### PR TITLE
Make InputLogic.onUpdateSelection behave closer to our documentation

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package helium314.keyboard.keyboard
 
-import android.os.SystemClock
 import android.text.InputType
 import android.util.SparseArray
 import android.view.KeyEvent
@@ -351,9 +350,7 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
             }
             gestureMoveForwardHaptics(text.isNotEmpty())
         }
-        // onUpdateSelection after connection.setSelection is expected and doesn't trigger the shift state update
-        // so we force it when only moving the cursor, but only if onUpdateSelection is coming soon
-        inputLogic.moveExpectedUntil = SystemClock.elapsedRealtime() + 500
+        inputLogic.setExpectCursorMove()
 
         // the shortcut below causes issues due to horrible handling of text fields by Firefox and forks
         // issues:

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
@@ -350,6 +350,7 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
             }
             gestureMoveForwardHaptics(text.isNotEmpty())
         }
+        inputLogic.nextUpdateIsMove = true
 
         // the shortcut below causes issues due to horrible handling of text fields by Firefox and forks
         // issues:

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 package helium314.keyboard.keyboard
 
+import android.os.SystemClock
 import android.text.InputType
 import android.util.SparseArray
 import android.view.KeyEvent
@@ -350,7 +351,9 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
             }
             gestureMoveForwardHaptics(text.isNotEmpty())
         }
-        inputLogic.nextUpdateIsMove = true
+        // onUpdateSelection after connection.setSelection is expected and doesn't trigger the shift state update
+        // so we force it when only moving the cursor, but only if onUpdateSelection is coming soon
+        inputLogic.moveExpectedUntil = SystemClock.elapsedRealtime() + 500
 
         // the shortcut below causes issues due to horrible handling of text fields by Firefox and forks
         // issues:

--- a/app/src/main/java/helium314/keyboard/latin/RichInputConnection.java
+++ b/app/src/main/java/helium314/keyboard/latin/RichInputConnection.java
@@ -1187,8 +1187,4 @@ public final class RichInputConnection implements PrivateCommandPerformer {
         if (isConnected())
             InputConnectionCompat.commitContent(mIC, editorInfo, contentInfo, InputConnectionCompat.INPUT_CONTENT_GRANT_READ_URI_PERMISSION, null);
     }
-
-    public int getComposingLength() {
-        return mComposingText.length();
-    }
 }

--- a/app/src/main/java/helium314/keyboard/latin/RichInputConnection.java
+++ b/app/src/main/java/helium314/keyboard/latin/RichInputConnection.java
@@ -1187,4 +1187,8 @@ public final class RichInputConnection implements PrivateCommandPerformer {
         if (isConnected())
             InputConnectionCompat.commitContent(mIC, editorInfo, contentInfo, InputConnectionCompat.INPUT_CONTENT_GRANT_READ_URI_PERMISSION, null);
     }
+
+    public int getComposingLength() {
+        return mComposingText.length();
+    }
 }

--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -370,7 +370,7 @@ public final class InputLogic {
         mCursorMoveExpectedUntil = SystemClock.elapsedRealtime() + 500;
     }
 
-    private boolean isExpectCursorMove() {
+    private boolean mightBeExpectedCursorMove() {
         boolean isMove = mCursorMoveExpectedUntil > SystemClock.elapsedRealtime();
         mCursorMoveExpectedUntil = 0L;
         return isMove;
@@ -389,10 +389,11 @@ public final class InputLogic {
      */
     public boolean onUpdateSelection(int oldSelStart, int oldSelEnd, int newSelStart,
              int newSelEnd, int composingSpanStart, int composingSpanEnd, SettingsValues settingsValues) {
+        boolean expectCursorMove = mightBeExpectedCursorMove(); // reset the timer
         if (mConnection.isBelatedExpectedUpdate(oldSelStart, newSelStart, oldSelEnd, newSelEnd, composingSpanStart, composingSpanEnd)) {
             // return whether we expect a user-initiated explicit cursor move (i.e. not as result of other input, but e.g. space swipe)
             // note that arrow keys are not considered, because for them isBelatedExpectedUpdate returns false
-            return isExpectCursorMove();
+            return expectCursorMove;
         }
 
         // if all text is gone, we treat it like onStartInput

--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -364,7 +364,7 @@ public final class InputLogic {
     }
 
     /** indicates that the next selection update is expected to be a cursor move (triggered by space swipe) */
-    public boolean nextUpdateIsMove = false;
+    public long moveExpectedUntil = 0L;
 
     /**
      * Consider an update to the cursor position. Evaluate whether this update has happened as
@@ -379,11 +379,8 @@ public final class InputLogic {
      */
     public boolean onUpdateSelection(int oldSelStart, int oldSelEnd, int newSelStart,
              int newSelEnd, int composingSpanStart, int composingSpanEnd, SettingsValues settingsValues) {
-        if (nextUpdateIsMove) {
-            nextUpdateIsMove = false;
-            // sanity check because some apps don't stick to Android documentation and don't do onUpdateSelection when they should
-            if (newSelStart == newSelEnd && composingSpanEnd - composingSpanStart == mConnection.getComposingLength())
-                return true;
+        if (moveExpectedUntil > SystemClock.elapsedRealtime()) {
+            moveExpectedUntil = 0L;
         }
         if (mConnection.isBelatedExpectedUpdate(oldSelStart, newSelStart, oldSelEnd, newSelEnd, composingSpanStart, composingSpanEnd)) {
             return false;

--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -9,6 +9,7 @@ package helium314.keyboard.latin.inputlogic;
 import static helium314.keyboard.latin.common.SuggestionSpanUtilsKt.getTextWithSuggestionSpan;
 
 import android.graphics.Color;
+import android.os.Build;
 import android.os.SystemClock;
 import android.text.InputType;
 import android.text.SpannableString;
@@ -24,6 +25,7 @@ import android.view.inputmethod.EditorInfo;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import helium314.keyboard.compat.AppWorkarounds;
 import helium314.keyboard.event.Event;
 import helium314.keyboard.event.InputTransaction;
 import helium314.keyboard.keyboard.Keyboard;

--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -365,7 +365,7 @@ public final class InputLogic {
         return inputTransaction;
     }
 
-    /** indicates that the next selection update is expected to be a cursor move (triggered by space swipe, not arrow keys) */
+    /** indicates that the next selection update is expected to be a cursor move (though not needed for arrow keys) */
     public void setExpectCursorMove() {
         mCursorMoveExpectedUntil = SystemClock.elapsedRealtime() + 500;
     }

--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -9,7 +9,6 @@ package helium314.keyboard.latin.inputlogic;
 import static helium314.keyboard.latin.common.SuggestionSpanUtilsKt.getTextWithSuggestionSpan;
 
 import android.graphics.Color;
-import android.os.Build;
 import android.os.SystemClock;
 import android.text.InputType;
 import android.text.SpannableString;
@@ -25,7 +24,6 @@ import android.view.inputmethod.EditorInfo;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import helium314.keyboard.compat.AppWorkarounds;
 import helium314.keyboard.event.Event;
 import helium314.keyboard.event.InputTransaction;
 import helium314.keyboard.keyboard.Keyboard;
@@ -128,6 +126,8 @@ public final class InputLogic {
     private String mWordBeingCorrectedByCursor = null;
 
     private boolean mJustRevertedACommit = false;
+
+    private long mCursorMoveExpectedUntil = 0L;
 
     /**
      * Create a new instance of the input logic.
@@ -363,8 +363,16 @@ public final class InputLogic {
         return inputTransaction;
     }
 
-    /** indicates that the next selection update is expected to be a cursor move (triggered by space swipe) */
-    public long moveExpectedUntil = 0L;
+    /** indicates that the next selection update is expected to be a cursor move (triggered by space swipe, not arrow keys) */
+    public void setExpectCursorMove() {
+        mCursorMoveExpectedUntil = SystemClock.elapsedRealtime() + 500;
+    }
+
+    private boolean isExpectCursorMove() {
+        boolean isMove = mCursorMoveExpectedUntil > SystemClock.elapsedRealtime();
+        mCursorMoveExpectedUntil = 0L;
+        return isMove;
+    }
 
     /**
      * Consider an update to the cursor position. Evaluate whether this update has happened as
@@ -379,11 +387,10 @@ public final class InputLogic {
      */
     public boolean onUpdateSelection(int oldSelStart, int oldSelEnd, int newSelStart,
              int newSelEnd, int composingSpanStart, int composingSpanEnd, SettingsValues settingsValues) {
-        if (moveExpectedUntil > SystemClock.elapsedRealtime()) {
-            moveExpectedUntil = 0L;
-        }
         if (mConnection.isBelatedExpectedUpdate(oldSelStart, newSelStart, oldSelEnd, newSelEnd, composingSpanStart, composingSpanEnd)) {
-            return false;
+            // return whether we expect a user-initiated explicit cursor move (i.e. not as result of other input, but e.g. space swipe)
+            // note that arrow keys are not considered, because for them isBelatedExpectedUpdate returns false
+            return isExpectCursorMove();
         }
 
         // if all text is gone, we treat it like onStartInput

--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -363,6 +363,9 @@ public final class InputLogic {
         return inputTransaction;
     }
 
+    /** indicates that the next selection update is expected to be a cursor move (triggered by space swipe) */
+    public boolean nextUpdateIsMove = false;
+
     /**
      * Consider an update to the cursor position. Evaluate whether this update has happened as
      * part of normal typing or whether it was an explicit cursor move by the user. In any case,
@@ -374,8 +377,14 @@ public final class InputLogic {
      * @param settingsValues the current values of the settings.
      * @return whether the cursor has moved as a result of user interaction.
      */
-    public boolean onUpdateSelection(final int oldSelStart, final int oldSelEnd, final int newSelStart,
-             final int newSelEnd, final int composingSpanStart, final int composingSpanEnd, final SettingsValues settingsValues) {
+    public boolean onUpdateSelection(int oldSelStart, int oldSelEnd, int newSelStart,
+             int newSelEnd, int composingSpanStart, int composingSpanEnd, SettingsValues settingsValues) {
+        if (nextUpdateIsMove) {
+            nextUpdateIsMove = false;
+            // sanity check because some apps don't stick to Android documentation and don't do onUpdateSelection when they should
+            if (newSelStart == newSelEnd && composingSpanEnd - composingSpanStart == mConnection.getComposingLength())
+                return true;
+        }
         if (mConnection.isBelatedExpectedUpdate(oldSelStart, newSelStart, oldSelEnd, newSelEnd, composingSpanStart, composingSpanEnd)) {
             return false;
         }


### PR DESCRIPTION
This makes `onUpdateSelection` return true after moving the cursor with space swipe. The return value should be _whether the cursor has moved as a result of user interaction_.
This is used in LatimIME to update the shift state if the user moved the cursor.

@eranl could use this behavior for #2292
@devycarol also noticed incorrect shift state, see https://github.com/HeliBorg/HeliBoard/pull/2586#discussion_r3540188763

I don't like the approach of just setting the value before sending the selection update, because then we're at mercy of the text field to actually call `LatinIME.onUpdateSelection`, and do it in correct order. Firefox is probably the most relevant app that in some case doesn't call it even though it's [supposed to](https://developer.android.com/reference/android/view/inputmethod/InputConnection#setSelection(int,%20int)). I added some basic check, because currently the move should never result in having a selection, and never changes the composing region.
And I also don't like it because it feels like an awful way of handling this situation, But if it works and I don't have a better idea... then I'll just do it.

@devycarol you said the shift state update _doesn't happen with space slide or arrow keys_. However in my tests arrow keys worked, only space swipe didn't.

Also I consider further limiting the `nextUpdateIsMove` logic to work only in a limited timespan of maybe 100 ms, so an expected selection update not happening can't break that much.

Further I tried to just not set `mExpectedSelStart` and `mExpectedSelEnd` in `RichInputConnection.setSelection` when calling from `onMoveCursorHorizontally`, but this gave very broken movement a not reproducible weird crash.