### PR TITLE
Refresh ic_ime_switcher icon and add a dedicated split keyboard icon

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/internal/KeyboardIconsSet.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/KeyboardIconsSet.kt
@@ -154,7 +154,7 @@ class KeyboardIconsSet private constructor() {
                     ToolbarKey.FULL_RIGHT -> R.drawable.ic_to_end
                     ToolbarKey.PAGE_START -> R.drawable.ic_page_start
                     ToolbarKey.PAGE_END -> R.drawable.ic_page_end
-                    ToolbarKey.SPLIT -> R.drawable.ic_ime_switcher
+                    ToolbarKey.SPLIT -> R.drawable.ic_split_keyboard
                     ToolbarKey.BACKGROUND_GATHERING -> R.drawable.ic_settings_gesture
                 })
             }
@@ -217,7 +217,7 @@ class KeyboardIconsSet private constructor() {
                     ToolbarKey.FULL_RIGHT -> R.drawable.ic_to_end
                     ToolbarKey.PAGE_START -> R.drawable.ic_page_start
                     ToolbarKey.PAGE_END -> R.drawable.ic_page_end
-                    ToolbarKey.SPLIT -> R.drawable.ic_ime_switcher
+                    ToolbarKey.SPLIT -> R.drawable.ic_split_keyboard
                     ToolbarKey.BACKGROUND_GATHERING -> R.drawable.ic_settings_gesture
                 })
             }
@@ -280,7 +280,7 @@ class KeyboardIconsSet private constructor() {
                     ToolbarKey.FULL_RIGHT -> R.drawable.ic_to_end_rounded
                     ToolbarKey.PAGE_START -> R.drawable.ic_page_start_rounded
                     ToolbarKey.PAGE_END -> R.drawable.ic_page_end_rounded
-                    ToolbarKey.SPLIT -> R.drawable.ic_ime_switcher
+                    ToolbarKey.SPLIT -> R.drawable.ic_split_keyboard
                     ToolbarKey.BACKGROUND_GATHERING -> R.drawable.ic_settings_gesture
                 })
             }

--- a/app/src/main/res/drawable/ic_ime_switcher.xml
+++ b/app/src/main/res/drawable/ic_ime_switcher.xml
@@ -1,5 +1,6 @@
 <!--
-    icon from pictogrammers.com
+    SPDX-FileCopyrightText: Material Design Authors / Google LLC
+    modified
     SPDX-License-Identifier: Apache-2.0
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
@@ -8,6 +9,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="#FFF"
-        android:pathData="M6,16H18V18H6V16M6,13V15H2V13H6M7,15V13H10V15H7M11,15V13H13V15H11M14,15V13H17V15H14M18,15V13H22V15H18M2,10H5V12H2V10M19,12V10H22V12H19M18,12H16V10H18V12M8,12H6V10H8V12M12,12H9V10H12V12M15,12H13V10H15V12M2,9V7H4V9H2M5,9V7H7V9H5M8,9V7H10V9H8M11,9V7H13V9H11M14,9V7H16V9H14M17,9V7H22V9H17Z"/>
+        android:fillColor="@color/foreground"
+        android:pathData="m6.167,17.833v-2.333h11.667v2.333zM1.5,13.167v-2.333h2.333v2.333zM6.167,13.167v-2.333L8.5,10.833v2.333zM10.833,13.167v-2.333h2.333v2.333zM15.5,13.167v-2.333h2.333v2.333zM20.167,13.167v-2.333L22.5,10.833v2.333zM1.5,8.5v-2.333L3.833,6.167L3.833,8.5ZM6.167,8.5v-2.333L8.5,6.167L8.5,8.5ZM10.833,8.5v-2.333h2.333L13.167,8.5ZM15.5,8.5v-2.333h2.333L17.833,8.5ZM20.167,8.5v-2.333L22.5,6.167L22.5,8.5Z" />
 </vector>

--- a/app/src/main/res/drawable/ic_split_keyboard.xml
+++ b/app/src/main/res/drawable/ic_split_keyboard.xml
@@ -1,0 +1,14 @@
+<!--
+    SPDX-FileCopyrightText: Material Design Authors / Google LLC
+    modified
+    SPDX-License-Identifier: Apache-2.0
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/foreground"
+        android:pathData="M1.5,6.167L1.5,8.5h2.333v-2.333zM5.232,6.167L5.232,8.5h2.333v-2.333zM12.7,6.167L12.7,8.5h2.333v-2.333zM16.434,6.167L16.434,8.5h2.333v-2.333zM20.167,6.167L20.167,8.5L22.5,8.5v-2.333zM1.5,10.833v2.333h2.333v-2.333zM5.232,10.833v2.333h2.333v-2.333zM8.967,10.833v2.333h2.333v-2.333zM16.434,10.833v2.333h2.333v-2.333zM20.167,10.833v2.333L22.5,13.167v-2.333zM6.167,15.5v2.333L17.833,17.833L17.833,15.5Z" />
+</vector>


### PR DESCRIPTION
Replaced the previous `ic_ime_switcher` icon with a cleaner Material icon. The old icon was a bit too detailed and visually busy.
<img width="56" height="56" alt="keyboard" src="https://github.com/user-attachments/assets/06b36dc3-6066-45bf-9ea4-6bf85ed36e96" />

Added a dedicated icon for Split Keyboard instead of reusing the IME switcher icon.
<img width="56" height="56" alt="layout_split" src="https://github.com/user-attachments/assets/c7649968-93c0-48a6-a082-c34597599771" />



