### PR TITLE
Make the numpad visually aligned with the symbols layout

### DIFF
--- a/app/src/main/assets/layouts/numpad/numpad.json
+++ b/app/src/main/assets/layouts/numpad/numpad.json
@@ -1,6 +1,6 @@
 [
-  [
-    { "label": "+", "type":  "function", "popup": {
+  [ 
+    { "label": "+", "type":  "function", "width": 0.15, "popup": {
       "relevant": [
         { "label": "(" },
         { "label": "<" },
@@ -10,10 +10,10 @@
     { "label": "1", "type": "numeric" },
     { "label": "2", "type": "numeric" },
     { "label": "3", "type": "numeric" },
-    { "label": "%", "type":  "function", "popup": { "main": { "label": "$$$"} }, "labelFlags": 512 }
+    { "label": "%", "type":  "function", "width": 0.15, "popup": { "main": { "label": "$$$"} }, "labelFlags": 512 }
   ],
   [
-    { "label": "-", "type":  "function", "popup": {
+    { "label": "-", "type":  "function", "width": 0.15, "popup": {
       "relevant": [
         { "label": ")" },
         { "label": ">" },
@@ -23,10 +23,10 @@
     { "label": "4", "type": "numeric" },
     { "label": "5", "type": "numeric" },
     { "label": "6", "type": "numeric" },
-    { "label": "space", "type":  "function" }
+    { "label": "space", "type":  "function", "width": 0.15 }
   ],
   [
-    { "label": "*", "type":  "function", "popup": {
+    { "label": "*", "type":  "function", "width": 0.15, "popup": {
       "relevant": [
         { "label": "/" },
         { "label": "×" },
@@ -36,15 +36,15 @@
     { "label": "7", "type": "numeric" },
     { "label": "8", "type": "numeric" },
     { "label": "9", "type": "numeric" },
-    { "label": "delete" }
+    { "label": "delete", "width": 0.15 }
   ],
   [
-    { "label": "alpha" },
-    { "label": "comma", "width":  0.1, "labelFlags": 1073741824 },
-    { "label": "symbol", "width":  0.12 },
+    { "label": "alpha", "width": 0.15 },
+    { "label": "comma", "width": 0.1, "labelFlags": 1073741824 },
+    { "label": "symbol", "width": 0.1 },
     { "label": "0", "type": "numeric" },
-    { "label": "=", "type": "function", "width":  0.12, "popup": { "relevant": [ { "label": "≠"}, { "label": "≈"} ] } },
-    { "label": "period", "width":  0.1 },
-    { "label": "action" }
+    { "label": "=", "type": "function", "width": 0.1, "popup": { "relevant": [ { "label": "≠"}, { "label": "≈"} ] } },
+    { "label": "period", "width": 0.1 },
+    { "label": "action", "width": 0.15 }
   ]
 ]

--- a/app/src/main/assets/layouts/numpad/numpad.json
+++ b/app/src/main/assets/layouts/numpad/numpad.json
@@ -40,11 +40,11 @@
   ],
   [
     { "label": "alpha", "width": 0.15 },
-    { "label": "comma", "width": 0.1, "labelFlags": 1073741824 },
-    { "label": "symbol", "width": 0.1 },
+    { "label": "comma", "width": 0.116, "labelFlags": 1073741824 },
+    { "label": "symbol", "width": 0.116 },
     { "label": "0", "type": "numeric" },
-    { "label": "=", "type": "function", "width": 0.1, "popup": { "relevant": [ { "label": "≠"}, { "label": "≈"} ] } },
-    { "label": "period", "width": 0.1 },
+    { "label": "=", "type": "function", "width": 0.116, "popup": { "relevant": [ { "label": "≠"}, { "label": "≈"} ] } },
+    { "label": "period", "width": 0.116 },
     { "label": "action", "width": 0.15 }
   ]
 ]

--- a/app/src/main/assets/layouts/numpad/numpad.json
+++ b/app/src/main/assets/layouts/numpad/numpad.json
@@ -1,6 +1,6 @@
 [
   [ 
-    { "label": "+", "type":  "function", "width": 0.15, "popup": {
+    { "label": "+", "type": "function", "width": 0.15, "popup": {
       "relevant": [
         { "label": "(" },
         { "label": "<" },
@@ -10,10 +10,10 @@
     { "label": "1", "type": "numeric" },
     { "label": "2", "type": "numeric" },
     { "label": "3", "type": "numeric" },
-    { "label": "%", "type":  "function", "width": 0.15, "popup": { "main": { "label": "$$$"} }, "labelFlags": 512 }
+    { "label": "%", "type": "function", "width": 0.15, "popup": { "main": { "label": "$$$"} }, "labelFlags": 512 }
   ],
   [
-    { "label": "-", "type":  "function", "width": 0.15, "popup": {
+    { "label": "-", "type": "function", "width": 0.15, "popup": {
       "relevant": [
         { "label": ")" },
         { "label": ">" },
@@ -23,10 +23,10 @@
     { "label": "4", "type": "numeric" },
     { "label": "5", "type": "numeric" },
     { "label": "6", "type": "numeric" },
-    { "label": "space", "type":  "function", "width": 0.15 }
+    { "label": "space", "type": "function", "width": 0.15 }
   ],
   [
-    { "label": "*", "type":  "function", "width": 0.15, "popup": {
+    { "label": "*", "type": "function", "width": 0.15, "popup": {
       "relevant": [
         { "label": "/" },
         { "label": "×" },


### PR DESCRIPTION
updated the numpad layout so it visually aligns with the symbols layout.

Current | Proposed
-- | -- 
<img width="720" alt="current" src="https://github.com/user-attachments/assets/4ccc69da-0e70-4260-b1d2-c0d3458852bf" /> | <img width="720" alt="proposed" src="https://github.com/user-attachments/assets/0582fda0-127f-4dbf-895d-93cc1d0daf52" />
