### PR TITLE
fix(holo): gray functional/action keys with dynamic colors in light mode

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/common/Colors.kt
+++ b/app/src/main/java/helium314/keyboard/latin/common/Colors.kt
@@ -312,7 +312,15 @@ class DynamicColors(context: Context, override val themeStyle: String, override 
             drawable.colorFilter = getColorFilter(color)
             return
         }
-        DrawableCompat.setTintMode(drawable, PorterDuff.Mode.MULTIPLY)
+        // The Holo functional/action key backgrounds are grey nine-patches. Tinting them with
+        // MULTIPLY turns a light (e.g. dynamic/Material You) accent into grey (#2052), because
+        // grey * pastel stays grey. SRC_IN replaces the grey with the tint instead. Restricted to
+        // Holo light + these two backgrounds so tuned static themes and dark mode are unaffected.
+        val tintMode = if (themeStyle == STYLE_HOLO && !isNight
+                && (color == FUNCTIONAL_KEY_BACKGROUND || color == ACTION_KEY_BACKGROUND))
+            PorterDuff.Mode.SRC_IN
+        else PorterDuff.Mode.MULTIPLY
+        DrawableCompat.setTintMode(drawable, tintMode)
         DrawableCompat.setTintList(drawable, colorStateList)
     }
 


### PR DESCRIPTION
Fixes #2052.

## Cause
Holo's functional-key background is an intrinsically gray 9-patch (`themes-holo_base.xml` → `btn_keyboard_key_pressed_klp_light`, center pixel RGB(131,131,131)), and `DynamicColors.setColor` tints key backgrounds with `PorterDuff.Mode.MULTIPLY`. Multiplying the light dynamic accents (`system_accent2_100` etc.) by that gray caps brightness and strips the chroma, so the keys turn gray. The other styles use white/neutral drawables, where MULTIPLY passes the tint through. The static Holo themes already compensate for this in their color *choices* (see `KeyboardTheme.kt`: "should be 222222, but the key drawable is already grey") — `DynamicColors` doesn't. Dark mode isn't affected because the night functional tint is gray anyway.

## Fix
Use `SRC_IN` instead of `MULTIPLY`, limited to `DynamicColors` + Holo + light + the functional/action backgrounds. `SRC_IN` rather than `SRC_ATOP` on purpose: with key borders disabled the normal-state tint is `Color.TRANSPARENT`, and SRC_IN keeps that invisible. `DefaultColors` is left untouched — its static themes are tuned around MULTIPLY.

## Result — Holo + dynamic colors + light + key borders

| before | after |
| --- | --- |
|  <img src="https://github.com/user-attachments/assets/fe3e2f0d-dfde-4f28-9593-32890c1674fc" /> | <img src="https://github.com/user-attachments/assets/4f2e2553-ddac-4d46-b114-e1685d9653c4" /> |

Pixel check on those shots: functional key (shift / ?123) RGB(125,114,98) → (244,224,191); action key (119,98,62) → (232,193,121); a normal letter key is identical in both (248,236,222).

Scope: only `DynamicColors` in light mode, only the functional/action backgrounds. Dark mode, the other theme styles, and the static themes are unchanged.