### PR TITLE
Make the floating keyboard's drag/resize handles reachable

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -1218,7 +1218,11 @@ public class LatinIME extends InputMethodService implements
                 touchLeft = xy.component1();
                 touchTop = xy.component2();
                 touchRight = touchLeft + mSettings.getCurrent().mFloatingWidth;
-                touchBottom = touchTop + mSettings.getCurrent().mFloatingHeight + stripHeight + (int)FloatingKeyboardUtils.getFloatingHandleHeight(getResources());
+                // the floating input view wraps the whole floating keyboard (suggestion strip + keyboard +
+                // drag/resize handles), so its measured height is the exact reach; the old estimate used the
+                // configured mFloatingHeight, which is smaller than the rendered keyboard, leaving the bottom
+                // handles outside the touchable region (touches fell through to the app behind)
+                touchBottom = touchTop + inputHeight;
             }
             outInsets.touchableInsets = InputMethodService.Insets.TOUCHABLE_INSETS_REGION;
             outInsets.touchableRegion.set(touchLeft, touchTop, touchRight, touchBottom);

--- a/app/src/main/java/helium314/keyboard/latin/utils/FloatingKeyboardUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/utils/FloatingKeyboardUtils.kt
@@ -4,11 +4,14 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.Resources
 import android.graphics.Rect
+import android.os.Build
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.core.content.edit
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import helium314.keyboard.keyboard.KeyboardSwitcher
@@ -27,6 +30,16 @@ object FloatingKeyboardUtils {
     fun setFloating(view: View?) {
         val lp = view?.layoutParams as? ViewGroup.MarginLayoutParams ?: return
         view.getWindowVisibleDisplayFrame(windowFrame)
+        // Android 15+ enforces edge-to-edge, so the IME window draws behind the navigation bar and the
+        // visible frame still spans behind it; the bottom drag/resize handles would otherwise end up
+        // under the nav bar. Subtract the window's nav bar inset to keep them reachable. Older versions
+        // keep the IME above the nav bar, so no adjustment is needed there (and applying it could
+        // subtract the nav bar height a second time and lift the keyboard off the bottom).
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            val navBarBottom = ViewCompat.getRootWindowInsets(view)
+                ?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom ?: 0
+            windowFrame.bottom -= navBarBottom
+        }
         extraHeight = getSuggestionStripHeight(view.resources) + getFloatingHandleHeight(view.resources)
         val (x, y) = readPosition(
             view.context,


### PR DESCRIPTION
The floating keyboard's bottom drag/resize handles were often unreachable — the IME touchable region was computed from the configured `mFloatingHeight`, which is smaller than the rendered keyboard, so the handles fell outside it and touches passed through to the app behind. This uses the floating input view's measured height instead. On Android 15+ (edge-to-edge, IME draws behind the navigation bar) it also subtracts the nav-bar inset so the handles stay above it.

Fixes #2610, #2680.