### PR TITLE
Keep the toolbar expand/collapse state across reopening the keyboard

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -1119,8 +1119,9 @@ public class LatinIME extends InputMethodService implements
     @Override
     public void hideWindow() {
         Log.i(TAG, "hideWindow");
-        if (hasSuggestionStripView() && mSettings.getCurrent().mToolbarMode == ToolbarMode.EXPANDABLE)
-            mSuggestionStripView.setToolbarVisibility(false);
+        // keep the toolbar expand/collapse state across closing and reopening the keyboard; the
+        // "auto show"/"auto hide toolbar" settings still control it while typing, but closing the
+        // window no longer forces it back to the suggestion strip
         mKeyboardSwitcher.onHideWindow();
 
         if (TRACE) Debug.stopMethodTracing();


### PR DESCRIPTION
`hideWindow()` force-collapsed the expandable toolbar back to the suggestion strip whenever the keyboard closed. Dropping that lets the last toolbar state persist across close/reopen; the "auto show" / "auto hide toolbar" settings still control it while typing.

Related: #2379