### PR TITLE
Fix recents not refreshing on clear-all, and pending keys surviving a clear

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/emoji/DynamicGridKeyboard.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/emoji/DynamicGridKeyboard.java
@@ -180,6 +180,9 @@ final class DynamicGridKeyboard extends Keyboard {
     public void removeAllKeys() {
         synchronized (mLock) {
             mGridKeys.clear();
+            // also drop keys typed while viewing the recents tab that haven't been flushed yet,
+            // otherwise they get re-added on the next flushPendingRecentKeys() after a clear-all
+            mPendingKeys.clear();
             mCachedGridKeys = null;
         }
     }

--- a/app/src/main/java/helium314/keyboard/keyboard/emoji/EmojiPalettesView.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/emoji/EmojiPalettesView.java
@@ -167,6 +167,16 @@ public final class EmojiPalettesView extends LinearLayout
             return view.findViewById(R.id.emoji_keyboard_list);
         }
 
+        /** Rebuild the recents page while it is the currently visible page. notifyItemChanged does not
+         *  rebind the current ViewPager2 page, so refresh its inner adapter directly (same as the
+         *  tab-change path in onViewDetachedFromWindow). No-op if recents is not currently bound. */
+        void refreshVisibleRecents() {
+            final RecyclerView recyclerView = mViews.get(mEmojiCategory.getRecentTabId());
+            if (recyclerView != null && recyclerView.getAdapter() != null) {
+                recyclerView.getAdapter().notifyDataSetChanged();
+            }
+        }
+
         private void updateState(@NonNull RecyclerView recyclerView, long categoryId) {
             if (categoryId != mEmojiCategory.getCurrentCategory().ordinal()) {
                 return;
@@ -333,6 +343,10 @@ public final class EmojiPalettesView extends LinearLayout
     private void clearRecentKeys() {
         RecentEmojis.clear();
         getRecentsKeyboard().removeAllKeys();
+        // clearing happens while the recents tab is visible (its icon is long-pressed), where a plain
+        // notifyItemChanged does not rebind the current page - refresh the visible recents grid directly
+        if (initialized && mPager.getAdapter() instanceof PagerAdapter adapter)
+            adapter.refreshVisibleRecents();
     }
 
     @Override


### PR DESCRIPTION
On the `remove_recents` rework, `clearRecentKeys()` clears `RecentEmojis` and the grid but never tells the view to refresh, so long-pressing the recents tab icon leaves the now-empty grid on screen until the tab is switched. `notifyItemChanged` does not rebind the currently visible `ViewPager2` page, so refresh the visible recents page's inner adapter directly, mirroring the tab-change path in `onViewDetachedFromWindow`.

`removeAllKeys()` also cleared `mGridKeys` but not `mPendingKeys`, so an emoji typed while viewing the recents tab survived a clear-all and was re-added by the next `flushPendingRecentKeys()`. Clear pending keys too.

Tested on-device.