### PR TITLE
Use system voice input

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@ SPDX-License-Identifier: Apache-2.0 AND GPL-3.0-only
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WRITE_USER_DICTIONARY" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <application android:label="@string/english_ime_name"
             android:name="helium314.keyboard.latin.App"

--- a/app/src/main/java/helium314/keyboard/keyboard/voice/ListenState.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/voice/ListenState.java
@@ -1,0 +1,7 @@
+package helium314.keyboard.keyboard.voice;
+
+enum ListenState {
+    NOT_LISTENING,
+    WAITING,
+    LISTENING,
+}

--- a/app/src/main/java/helium314/keyboard/keyboard/voice/VoiceTranscriber.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/voice/VoiceTranscriber.java
@@ -1,0 +1,131 @@
+package helium314.keyboard.keyboard.voice;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.speech.RecognitionListener;
+import android.speech.RecognizerIntent;
+import android.speech.SpeechRecognizer;
+import android.util.Log;
+
+import java.util.ArrayList;
+
+public final class VoiceTranscriber {
+    private static final String TAG = VoiceTranscriber.class.getSimpleName();
+    private static final Intent INTENT = new Intent(
+        RecognizerIntent.ACTION_RECOGNIZE_SPEECH
+    ).putExtra(
+        RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+        RecognizerIntent.LANGUAGE_MODEL_FREE_FORM
+    ).putExtra(
+        // this is "best effort" at preventing the service from cutting the user
+        // off. in practice, they can ignore this or set a hard upper limit on
+        // the-timeout-that-shouldn't-be-there-to-begin-with. with the Google
+        // service, this at least affords the user a fairer amount of time than
+        // their IME does.
+        RecognizerIntent.EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS,
+        Integer.MAX_VALUE
+    );
+
+    private final SpeechRecognizer mSpeech;
+    private ListenState mListening = ListenState.NOT_LISTENING;
+
+    public VoiceTranscriber(Context ctx) {
+        ctx = ctx.getApplicationContext();
+        // todo: user preference to use createOnDeviceSpeechRecognizer(). note
+        //  that the Google service doesn't support this despite working without
+        //  internet. ??
+        //  for the older SDK versions, there's also some intent parameter that
+        //  asks nicely for that. ultimately, i'm 80% sure whether it's actually
+        //  on-device and private is up to whether you trust the developer. this
+        //  should be communicated to the user.
+        mSpeech = SpeechRecognizer.createSpeechRecognizer(ctx);
+        mSpeech.setRecognitionListener(new SpeechListener());
+    }
+
+    public void toggleListening() {
+        switch (mListening) {
+            case NOT_LISTENING -> {
+                // TODO LOL: permission request flow
+                mListening = ListenState.WAITING;
+                mSpeech.startListening(INTENT);
+            }
+            case WAITING -> {
+                // todo: have some sort of "toggle buffer" mechanism here so we
+                //  don't just eat inputs
+            }
+            case LISTENING -> {
+                mListening = ListenState.WAITING;
+                mSpeech.stopListening();
+            }
+        }
+    }
+
+    private void typeOut(String text) {
+        Log.d(TAG, text);
+    }
+
+    public void destroy() {
+        mSpeech.destroy();
+    }
+
+    private final class SpeechListener implements RecognitionListener {
+        @Override
+        public void onBeginningOfSpeech() {
+        }
+
+        @Override
+        public void onBufferReceived(byte[] buffer) {
+        }
+
+        @Override
+        public void onEndOfSpeech() {
+            // this means nothing, we don't decide when the user stops speaking.
+        }
+
+        @Override
+        public void onError(int error) {
+            mListening = ListenState.NOT_LISTENING;
+        }
+
+        @Override
+        public void onEvent(int eventType, Bundle params) {
+        }
+
+        @Override
+        public void onPartialResults(Bundle partialResults) {
+            ArrayList<String> recognitions
+                = partialResults.getStringArrayList(
+                    SpeechRecognizer.RESULTS_RECOGNITION
+                )
+            ;
+            if (recognitions == null || recognitions.isEmpty()) {
+                return;
+            }
+
+            typeOut(recognitions.get(0));
+            // so in theory, RESULTS_RECOGNITION is a list of different guesses
+            // for what the user said. in practice with the Google recognizer, I
+            // have only ever seen this be a singleton list. maybe to get
+            // additional hypotheses we need to pass some additional parameters
+            // in the recognizer intent? other results from a fully-fledged
+            // recognizer that would be helpful for correction suggestions
+            // include RESULTS_ALTERNATIVES and CONFIDENCE_SCORES.
+        }
+
+        @Override
+        public void onReadyForSpeech(Bundle params) {
+            mListening = ListenState.LISTENING;
+        }
+
+        @Override
+        public void onResults(Bundle results) {
+            mListening = ListenState.NOT_LISTENING;
+        }
+
+        @Override
+        public void onRmsChanged(float rmsdB) {
+            // todo: this could be used for a noise gauge graphic
+        }
+    }
+}

--- a/app/src/main/java/helium314/keyboard/keyboard/voice/VoiceTranscriber.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/voice/VoiceTranscriber.java
@@ -65,6 +65,10 @@ public final class VoiceTranscriber {
         Log.d(TAG, text);
     }
 
+    public void stopListening() {
+        mSpeech.stopListening();
+    }
+
     public void destroy() {
         mSpeech.destroy();
     }
@@ -103,6 +107,11 @@ public final class VoiceTranscriber {
                 return;
             }
 
+            // todo: the Google recognizer will put a leading space if it's
+            //  not the first transcription in the recording session. instead,
+            //  we should trim that and ourselves be the judge of whether the
+            //  transcription should be space-padded based on caret/selection
+            //  position and language properties.
             typeOut(recognitions.get(0));
             // so in theory, RESULTS_RECOGNITION is a list of different guesses
             // for what the user said. in practice with the Google recognizer, I

--- a/app/src/main/java/helium314/keyboard/keyboard/voice/VoiceTranscriber.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/voice/VoiceTranscriber.java
@@ -39,6 +39,10 @@ public final class VoiceTranscriber {
         //  asks nicely for that. ultimately, i'm 80% sure whether it's actually
         //  on-device and private is up to whether you trust the developer. this
         //  should be communicated to the user.
+        // todo: we need to replace the recognizer as soon as the user changes
+        //  their preferred recognizer in the system settings.
+        // TODO LOL: this call crashes when no service is available, so we need
+        //  to not do any of this if there's no recognizer.
         mSpeech = SpeechRecognizer.createSpeechRecognizer(ctx);
         mSpeech.setRecognitionListener(new SpeechListener());
     }

--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -46,6 +46,7 @@ import helium314.keyboard.keyboard.emoji.EmojiPalettesView;
 import helium314.keyboard.keyboard.emoji.EmojiSearchActivity;
 import helium314.keyboard.keyboard.internal.KeyboardIconsSet;
 import helium314.keyboard.keyboard.internal.keyboard_parser.floris.KeyCode;
+import helium314.keyboard.keyboard.voice.VoiceTranscriber;
 import helium314.keyboard.latin.common.InsetsOutlineProvider;
 import helium314.keyboard.dictionarypack.DictionaryPackConstants;
 import helium314.keyboard.event.Event;
@@ -186,6 +187,7 @@ public class LatinIME extends InputMethodService implements
 
     private GestureConsumer mGestureConsumer = GestureConsumer.NULL_GESTURE_CONSUMER;
 
+    private VoiceTranscriber mVoiceTranscriber;
     private final ClipboardHistoryManager mClipboardHistoryManager = new ClipboardHistoryManager(this);
 
     public static final class UIHandler extends LeakGuardHandlerWrapper<LatinIME> {
@@ -549,6 +551,15 @@ public class LatinIME extends InputMethodService implements
         super.onCreate();
 
         loadSettings();
+        // TODO LOL: this probably isn't the initialization strategy we want for
+        //  this thing—I'm not sure this is the intended use of
+        //  "displayContext"? and I don't know how the LatinIME lifecycle works,
+        //  this is just here for debug purposes. we also probably want to have
+        //  a config option for lazy vs. eager initialization of the speech
+        //  recognizer, as that takes some time. some may prefer reducing lag at
+        //  keyboard load, others may want to reduce lag for the first press of
+        //  the voice key.
+        mVoiceTranscriber = new VoiceTranscriber(mDisplayContext);
         mClipboardHistoryManager.onCreate();
         mHandler.onCreate();
         if (FoldableUtils.INSTANCE.isFoldable())
@@ -692,6 +703,13 @@ public class LatinIME extends InputMethodService implements
 
     @Override
     public void onDestroy() {
+        // TODO LOL: i don't actually have any idea how the LatinIME lifecycle
+        //  works. to prevent resource leaks, we need to attach the speech
+        //  recognizer to the lifecycle of something that makes sense for what
+        //  it is, and someone with more knowledge than me needs to make that
+        //  decision.
+        mVoiceTranscriber.destroy();
+        mVoiceTranscriber = null;
         mClipboardHistoryManager.onDestroy();
         mDictionaryFacilitator.closeDictionaries();
         mSettings.onDestroy();
@@ -1412,7 +1430,14 @@ public class LatinIME extends InputMethodService implements
     // completely replace #onCodeInput.
     public void onEvent(@NonNull final Event event) {
         if (KeyCode.VOICE_INPUT == event.getKeyCode()) {
-            mRichImm.switchToShortcutIme(this);
+            if (true) {
+                // TODO LOL: we need to choose whether to do this or that based on
+                //  user preferences and what apps/services are available on the
+                //  device.
+                mVoiceTranscriber.toggleListening();
+            } else {
+                mRichImm.switchToShortcutIme(this);
+            }
         }
         final InputTransaction completeInputTransaction =
                 mInputLogic.onCodeInput(mSettings.getCurrent(), event,

--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -1137,6 +1137,7 @@ public class LatinIME extends InputMethodService implements
     @Override
     public void hideWindow() {
         Log.i(TAG, "hideWindow");
+        mVoiceTranscriber.stopListening();
         if (hasSuggestionStripView() && mSettings.getCurrent().mToolbarMode == ToolbarMode.EXPANDABLE)
             mSuggestionStripView.setToolbarVisibility(false);
         mKeyboardSwitcher.onHideWindow();

--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -1137,6 +1137,7 @@ public class LatinIME extends InputMethodService implements
     @Override
     public void hideWindow() {
         Log.i(TAG, "hideWindow");
+        // TODO LOL: stop listening when the screen locks
         mVoiceTranscriber.stopListening();
         if (hasSuggestionStripView() && mSettings.getCurrent().mToolbarMode == ToolbarMode.EXPANDABLE)
             mSuggestionStripView.setToolbarVisibility(false);

--- a/app/src/main/java/helium314/keyboard/settings/SettingsContainer.kt
+++ b/app/src/main/java/helium314/keyboard/settings/SettingsContainer.kt
@@ -14,6 +14,7 @@ import helium314.keyboard.settings.screens.createGestureTypingSettings
 import helium314.keyboard.settings.screens.createLayoutSettings
 import helium314.keyboard.settings.screens.createPreferencesSettings
 import helium314.keyboard.settings.screens.createToolbarSettings
+import helium314.keyboard.settings.screens.createVoiceTypingSettings
 
 class SettingsContainer(context: Context) {
     private val list = createSettings(context)
@@ -64,7 +65,7 @@ class Setting(
 // intentionally not putting individual debug settings in here so user knows the context
 private fun createSettings(context: Context) = createAboutSettings(context) + createAppearanceSettings(context) +
         createCorrectionSettings(context) + createPreferencesSettings(context) + createToolbarSettings(context) +
-        createLayoutSettings(context) + createAdvancedSettings(context) +
+        createLayoutSettings(context) + createAdvancedSettings(context) + createVoiceTypingSettings(context) +
         if (JniUtils.sHaveGestureLib) createGestureTypingSettings(context) else emptyList()
 
 object SettingsWithoutKey {

--- a/app/src/main/java/helium314/keyboard/settings/SettingsNavHost.kt
+++ b/app/src/main/java/helium314/keyboard/settings/SettingsNavHost.kt
@@ -32,6 +32,7 @@ import helium314.keyboard.settings.screens.SecondaryLayoutScreen
 import helium314.keyboard.settings.screens.SubtypeScreen
 import helium314.keyboard.settings.screens.TextCorrectionScreen
 import helium314.keyboard.settings.screens.ToolbarScreen
+import helium314.keyboard.settings.screens.VoiceTypingScreen
 import helium314.keyboard.settings.screens.gesturedata.GestureDataScreen
 import helium314.keyboard.settings.screens.gesturedata.ReviewScreen
 import kotlinx.coroutines.CoroutineScope
@@ -78,6 +79,7 @@ fun SettingsNavHost(
                 onClickLanguage = { navController.navigate(SettingsDestination.Languages) },
                 onClickLayouts = { navController.navigate(SettingsDestination.Layouts) },
                 onClickDictionaries = { navController.navigate(SettingsDestination.Dictionaries) },
+                onClickVoiceTyping = { navController.navigate(SettingsDestination.VoiceTyping) },
                 onClickBack = ::goBack,
             )
         }
@@ -127,6 +129,9 @@ fun SettingsNavHost(
         composable(SettingsDestination.Dictionaries) {
             DictionaryScreen(onClickBack = ::goBack)
         }
+        composable(SettingsDestination.VoiceTyping) {
+            VoiceTypingScreen(onClickBack = ::goBack)
+        }
         composable(SettingsDestination.Layouts) {
             SecondaryLayoutScreen(onClickBack = ::goBack)
         }
@@ -164,6 +169,7 @@ object SettingsDestination {
     const val Subtype = "subtype/"
     const val Layouts = "layouts"
     const val Dictionaries = "dictionaries"
+    const val VoiceTyping = "voice_typing"
     val navTarget = MutableStateFlow(Settings)
 
     private val navScope = CoroutineScope(Dispatchers.Default)

--- a/app/src/main/java/helium314/keyboard/settings/screens/MainSettingsScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/MainSettingsScreen.kt
@@ -42,6 +42,7 @@ fun MainSettingsScreen(
     onClickLanguage: () -> Unit,
     onClickLayouts: () -> Unit,
     onClickDictionaries: () -> Unit,
+    onClickVoiceTyping: () -> Unit,
     onClickBack: () -> Unit,
 ) {
     SearchSettingsScreen(
@@ -109,6 +110,11 @@ fun MainSettingsScreen(
                     icon = R.drawable.ic_settings_advanced
                 ) { NextScreenIcon() }
                 Preference(
+                    name = stringResource(R.string.voice),
+                    onClick = onClickVoiceTyping,
+                    icon = R.drawable.sym_keyboard_voice_lxx
+                ) { NextScreenIcon() }
+                Preference(
                     name = stringResource(R.string.settings_screen_about),
                     onClick = onClickAbout,
                     icon = R.drawable.ic_settings_about
@@ -124,7 +130,7 @@ private fun PreviewScreen() {
     initPreview(LocalContext.current)
     Theme(previewDark) {
         Surface {
-            MainSettingsScreen({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {})
+            MainSettingsScreen({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {})
         }
     }
 }

--- a/app/src/main/java/helium314/keyboard/settings/screens/VoiceTypingScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/VoiceTypingScreen.kt
@@ -1,0 +1,57 @@
+package helium314.keyboard.settings.screens
+
+import android.annotation.SuppressLint
+import android.content.Context
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import helium314.keyboard.latin.R
+import helium314.keyboard.latin.settings.Settings
+import helium314.keyboard.latin.utils.Log
+import helium314.keyboard.latin.utils.Theme
+import helium314.keyboard.latin.utils.getActivity
+import helium314.keyboard.latin.utils.previewDark
+import helium314.keyboard.settings.SearchSettingsScreen
+import helium314.keyboard.settings.Setting
+import helium314.keyboard.settings.SettingsActivity
+import helium314.keyboard.settings.initPreview
+
+@Composable
+fun VoiceTypingScreen(
+    onClickBack: () -> Unit,
+) {
+    val b = (LocalContext.current.getActivity() as? SettingsActivity)?.prefChanged?.collectAsState()
+    if ((b?.value ?: 0) < 0)
+        Log.v("irrelevant", "stupid way to trigger recomposition on preference change")
+    val items = listOf(
+        Settings.PREF_ALWAYS_INCOGNITO_MODE,
+    )
+    SearchSettingsScreen(
+        onClickBack = onClickBack,
+        title = stringResource(R.string.voice),
+        settings = items
+    )
+}
+
+@SuppressLint("ApplySharedPref")
+fun createVoiceTypingSettings(context: Context) = listOf<Setting>(
+//    Setting(context, Settings.PREF_ALWAYS_INCOGNITO_MODE,
+//        R.string.incognito, R.string.prefs_force_incognito_mode_summary)
+//    {
+//        SwitchPreference(it, Defaults.PREF_ALWAYS_INCOGNITO_MODE) { KeyboardSwitcher.getInstance().setThemeNeedsReload() }
+//    },
+)
+
+@Preview
+@Composable
+private fun Preview() {
+    initPreview(LocalContext.current)
+    Theme(previewDark) {
+        Surface {
+            VoiceTypingScreen { }
+        }
+    }
+}


### PR DESCRIPTION
This branch has no code yet, but I'm opening this PR to synthesize all the duplicate voice input issues and create an outline for features to implement. I plan to at least start to work on the code for this in this branch.

Closes #764, closes #988, closes #2728 by implementing seamless voice recognition into the HeliBoard keyboard via the system speech recognition service. The voice key will use the system speech recognizer service to transcribe speech without closing the board. No more janky, laggy IME switching unless the user insists. This will almost certainly require the RECORD_AUDIO permission.

Closes #192, closes #1234, closes #2699 with the rationale that we make it a non-goal for HeliBoard to have its own self-specific voice recognition code. No accommodations need to be made for any specific recognizer app, the app just needs to implement the speech recognition service. Someone could even make a "voice recognizer service for HeliBoard" in that mold which would also be compatible with other apps.

## Behaviors

Add a settings page for voice input. In it add an option for voice key behavior. The default option will be in-board voice recognition with the system speech service. You can toggle to use a separate voice IME instead. In either case, you will be offered to choose a specific voice service or stick with the system default. Someone suggested also having an "always ask" option, I think a better alternative is to have the long press of the voice key be a selection dialog for voice recognizer/keyboard similar to the space long press. The preference may need to be ignored if there is a recognizer service but no voice IME or vice versa.

Voice recognition will need three states: off, listening, and waiting. The third is needed because it takes some time to load the recognizer, particularly when initializing it. Another voice typing option could be to always initialize the recognizer on keyboard load. Could cause unwanted resource usage but would alleviate startup delay when pressing the voice key.

You can apparently use intent parameters and such to request that the recognizer "prefer on-device recognition". This could be another default-on voice typing option.

We must not EVER, ever, ever, ever, ever stop listening for voice input just because the user hasn't spoken in the last 0.021 seconds. Every single damned time the Google voice IME stops listening to me right as I start to speak again because "wow!! hands free!!1!" makes me want to scream. We must only stop listening when the user *tells* us to.

## Possible future work

The VTT output should honor shift state. To do this, we would reject stupid capitalization coming from the Google or any other voice input service—don't accept capitalized words from the speech recognizer unless it is a proper noun. Seems simple enough, if (word is title case) and (word.toLowerCase(locale) is in dictionaryOf(locale)), force the lowercase word. You should be able to change the shift state between lowercase, shifted, and all caps while you are talking. This raises the question of where and how to start changing the words from the recognizer—shift the next word said by the user somehow using timestamps, or shift the next word to be output by the recognizer which may lag behind?

In general, you should be able to interleave voice input with tap/gesture typing. This presents the same challenges as handling shift state.

There should be a 'spelling mode' for when the user knows something they want to type isn't in the voice dictionary. So the dictionary would be clamped to just letter and special character names. A, Q, 9, #, (, space, etc. This would probably need a distinct recognizer with a more limited and precise dictionary, though you could have a hacky implementation of this using "rewrite rules". Bee -> b, be -> b, pound -> #, hash -> #, etc.