### PR TITLE
Make KeyboardSwitcher layout changes go through KeyboardState

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
@@ -62,7 +62,7 @@ import helium314.keyboard.latin.utils.ScriptUtils;
 import helium314.keyboard.latin.utils.SubtypeUtilsAdditional;
 import helium314.keyboard.latin.utils.ToolbarMode;
 
-public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
+public final class KeyboardSwitcher {
     private static final String TAG = KeyboardSwitcher.class.getSimpleName();
 
     private InputView mCurrentInputView;
@@ -111,7 +111,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
     private void initInternal(final LatinIME latinIme) {
         mLatinIME = latinIme;
         mRichImm = RichInputMethodManager.getInstance();
-        mState = new KeyboardState(this);
+        mState = new KeyboardState(new SwitchActions());
         mIsHardwareAcceleratedDrawingEnabled = mLatinIME.enableHardwareAcceleration();
     }
 
@@ -202,32 +202,6 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         }
     }
 
-    private void setKeyboard(final KeyboardElement keyboardElement, @NonNull final KeyboardSwitchState toggleState) {
-        // with a hardware keyboard we might get here without ever calling onCreateInputView, so don't crash
-        if (mKeyboardView == null) return;
-
-        // Make {@link MainKeyboardView} visible and hide {@link EmojiPalettesView}.
-        final SettingsValues currentSettingsValues = Settings.getValues();
-        setMainKeyboardFrame(currentSettingsValues, toggleState);
-        // TODO: pass this object to setKeyboard instead of getting the current values.
-        final MainKeyboardView keyboardView = mKeyboardView;
-        final Keyboard oldKeyboard = keyboardView.getKeyboard();
-        final Keyboard newKeyboard = mKeyboardLayoutSet.getKeyboard(keyboardElement);
-        keyboardView.setKeyboard(newKeyboard);
-        mCurrentInputView.setKeyboardTopPadding(newKeyboard.mTopPadding);
-        keyboardView.setKeyPreviewPopupEnabled(currentSettingsValues.mKeyPreviewPopupOn);
-        keyboardView.updateShortcutKey(mRichImm.isShortcutImeReady());
-        final boolean subtypeChanged = (oldKeyboard == null) || !newKeyboard.mId.getSubtype().equals(oldKeyboard.mId.getSubtype());
-        final int languageOnSpacebarFormatType = LanguageOnSpacebarUtils.getLanguageOnSpacebarFormatType(newKeyboard.mId.getSubtype());
-        final boolean hasMultipleEnabledIMEsOrSubtypes = mRichImm.hasMultipleEnabledIMEsOrSubtypes(true);
-        keyboardView.startDisplayLanguageOnSpacebar(subtypeChanged, languageOnSpacebarFormatType, hasMultipleEnabledIMEsOrSubtypes);
-
-        if (currentSettingsValues.needsToLookupSuggestions()
-                                    && (currentSettingsValues.mInlineEmojiSearch || currentSettingsValues.mSuggestEmojis)) {
-            EmojiParserKt.loadEmojiDefaultVersionsAndPopupSpecs(mThemeContext);
-        }
-    }
-
     @Nullable public Keyboard getKeyboard() {
         if (mKeyboardView != null) {
             return mKeyboardView.getKeyboard();
@@ -237,9 +211,8 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
 
     // TODO: Remove this method. Come up with a more comprehensive way to reset the keyboard layout
     // when a keyboard layout set doesn't get reloaded in LatinIME.onStartInputViewInternal().
-    public void resetKeyboardStateToAlphabet(final int currentAutoCapsState,
-            @Nullable final RecapitalizeMode currentRecapitalizeState) {
-        mState.onResetKeyboardStateToAlphabet(currentAutoCapsState, currentRecapitalizeState);
+    public void resetKeyboardStateToAlphabet() {
+        mState.onResetKeyboardStateToAlphabet(mLatinIME.getCurrentAutoCapsState(), mLatinIME.getCurrentRecapitalizeState());
     }
 
     public void onPressKey(int code, int pointerCount, int currentAutoCapsState,
@@ -257,31 +230,12 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         mState.onFinishSlidingInput(currentAutoCapsState, currentRecapitalizeState);
     }
 
-    // Implements {@link KeyboardState.SwitchActions}.
-    @Override
-    public void setAlphabetKeyboard(@NonNull ShiftMode shiftMode) {
-        if (DEBUG_ACTION) {
-            Log.d(TAG, "setAlphabetKeyboard");
-        }
-        setKeyboard(shiftMode.element, KeyboardSwitchState.OTHER);
+    public void setEmojiKeyboard() {
+        mState.setLayout(LayoutDirective.Utility.EMOJI);
     }
 
-    // Implements {@link KeyboardState.SwitchActions}.
-    @Override
-    public void setSymbolsKeyboard() {
-        if (DEBUG_ACTION) {
-            Log.d(TAG, "setSymbolsKeyboard");
-        }
-        setKeyboard(KeyboardElement.SYMBOLS, KeyboardSwitchState.OTHER);
-    }
-
-    // Implements {@link KeyboardState.SwitchActions}.
-    @Override
-    public void setSymbolsShiftedKeyboard() {
-        if (DEBUG_ACTION) {
-            Log.d(TAG, "setSymbolsShiftedKeyboard");
-        }
-        setKeyboard(KeyboardElement.SYMBOLS_SHIFTED, KeyboardSwitchState.SYMBOLS_SHIFTED);
+    public void setClipboardKeyboard() {
+        mState.setLayout(LayoutDirective.Utility.CLIPBOARD);
     }
 
     public boolean isImeSuppressedByHardwareKeyboard(
@@ -312,73 +266,12 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         mClipboardHistoryView.stopClipboardHistory();
     }
 
-    // Implements {@link KeyboardState.SwitchActions}.
-    @Override
-    public void setEmojiKeyboard() {
-        if (DEBUG_ACTION) {
-            Log.d(TAG, "setEmojiKeyboard");
-        }
-        mMainKeyboardFrame.setVisibility(View.VISIBLE);
-        // The visibility of {@link #mKeyboardView} must be aligned with {@link #MainKeyboardFrame}.
-        // @see #getVisibleKeyboardView() and
-        // @see LatinIME#onComputeInset(android.inputmethodservice.InputMethodService.Insets)
-        mKeyboardView.setVisibility(View.GONE);
-        mSuggestionStripView.setVisibility(View.GONE);
-        mStripContainer.setVisibility(getSecondaryStripVisibility());
-        mClipboardStripScrollView.setVisibility(View.GONE);
-        mEmojiTabStripView.setVisibility(View.VISIBLE);
-        mClipboardHistoryView.setVisibility(View.GONE);
-        mEmojiPalettesView.startEmojiPalettes(mKeyboardView.getKeyVisualAttribute(),
-                mLatinIME.getCurrentInputEditorInfo(), mLatinIME.mKeyboardActionListener);
-        mEmojiPalettesView.setVisibility(View.VISIBLE);
-    }
-
-    // Implements {@link KeyboardState.SwitchActions}.
-    @Override
-    public void setClipboardKeyboard() {
-        if (DEBUG_ACTION) {
-            Log.d(TAG, "setClipboardKeyboard");
-        }
-        mMainKeyboardFrame.setVisibility(View.VISIBLE);
-        // The visibility of {@link #mKeyboardView} must be aligned with {@link #MainKeyboardFrame}.
-        // @see #getVisibleKeyboardView() and
-        // @see LatinIME#onComputeInset(android.inputmethodservice.InputMethodService.Insets)
-        mKeyboardView.setVisibility(View.GONE);
-        mEmojiTabStripView.setVisibility(View.GONE);
-        mSuggestionStripView.setVisibility(View.GONE);
-        mStripContainer.setVisibility(getSecondaryStripVisibility());
-        mClipboardStripScrollView.post(() -> mClipboardStripScrollView.fullScroll(HorizontalScrollView.FOCUS_RIGHT));
-        mClipboardStripScrollView.setVisibility(View.VISIBLE);
-        mEmojiPalettesView.setVisibility(View.GONE);
-        mClipboardHistoryView.startClipboardHistory(mLatinIME.getClipboardHistoryManager(), mKeyboardView.getKeyVisualAttribute(),
-                mLatinIME.getCurrentInputEditorInfo(), mLatinIME.mKeyboardActionListener);
-        mClipboardHistoryView.setVisibility(View.VISIBLE);
-    }
-
-    @Override
-    public void setNumpadKeyboard() {
-        if (DEBUG_ACTION) {
-            Log.d(TAG, "setNumpadKeyboard");
-        }
-        setKeyboard(KeyboardElement.NUMPAD, KeyboardSwitchState.OTHER);
-    }
-
-    @Override
-    public void setDpadKeyboard() {
-        if (DEBUG_ACTION) {
-            Log.d(TAG, "setDpadKeyboard");
-        }
-        setKeyboard(KeyboardElement.DPAD, KeyboardSwitchState.OTHER);
-    }
-
-    @Override
     public void toggleLayout(@NonNull LayoutDirective.Utility layout, int autoCapsFlags, @Nullable RecapitalizeMode recapitalizeMode) {
         mState.toggleLayout(layout, autoCapsFlags, recapitalizeMode);
     }
 
-    @Override
     public void onLongPressAlphaSymbolForNumpad() {
-        if (DEBUG_ACTION) {
+        if (SwitchActions.DEBUG_ACTION) {
             Log.d(TAG, "onLongPressAlphaSymbol");
         }
         mState.onLongPressAlphaSymbolForNumpad();
@@ -421,7 +314,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         if (currentState == toggleState) {
             mLatinIME.stopShowingInputView();
             mLatinIME.hideWindow();
-            setAlphabetKeyboard(ShiftMode.UNSHIFT);
+            resetKeyboardStateToAlphabet();
         } else {
             mLatinIME.startShowingInputView(true);
             if (toggleState == KeyboardSwitchState.EMOJI) {
@@ -447,45 +340,11 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         }
     }
 
-    // Future method for requesting an updating to the shift state.
-    @Override
-    public void requestUpdatingShiftState(final int autoCapsFlags, @Nullable final RecapitalizeMode recapitalizeMode) {
-        if (DEBUG_ACTION) {
-            Log.d(TAG, "requestUpdatingShiftState: "
-                    + " autoCapsFlags=" + CapsModeUtils.flagsToString(autoCapsFlags)
-                    + " recapitalizeMode=" + recapitalizeMode);
+    public void updateShiftState(final int autoCapsFlags, @Nullable final RecapitalizeMode recapitalizeMode) {
+        if (SwitchActions.DEBUG_ACTION) {
+            Log.d(TAG, "updateShiftState: " + " autoCapsFlags=" + CapsModeUtils.flagsToString(autoCapsFlags) + " recapitalizeMode=" + recapitalizeMode);
         }
         mState.onUpdateShiftState(autoCapsFlags, recapitalizeMode);
-    }
-
-    // Implements {@link KeyboardState.SwitchActions}.
-    @Override
-    public void startDoubleTapShiftKeyTimer() {
-        if (DEBUG_TIMER_ACTION) {
-            Log.d(TAG, "startDoubleTapShiftKeyTimer");
-        }
-        final MainKeyboardView keyboardView = getMainKeyboardView();
-        if (keyboardView != null) {
-            keyboardView.startDoubleTapShiftKeyTimer();
-        }
-    }
-
-    // Implements {@link KeyboardState.SwitchActions}.
-    @Override
-    public void cancelDoubleTapShiftKeyTimer() {
-        if (DEBUG_TIMER_ACTION) {
-            Log.d(TAG, "cancelDoubleTapShiftKeyTimer");
-        }
-        final MainKeyboardView keyboardView = getMainKeyboardView();
-        if (keyboardView != null) {
-            keyboardView.cancelDoubleTapShiftKeyTimer();
-        }
-    }
-
-    // Implements {@link KeyboardState.SwitchActions}.
-    @Override
-    public void setOneHandedModeEnabled(boolean enabled) {
-        setOneHandedModeEnabled(enabled, false);
     }
 
     public void setOneHandedModeEnabled(boolean enabled, boolean force) {
@@ -500,23 +359,6 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         if (enabled != settings.getCurrent().mOneHandedModeEnabled)
             settings.writeOneHandedModeEnabled(enabled);
         reloadKeyboard();
-    }
-
-    // Implements {@link KeyboardState.SwitchActions}.
-    @Override
-    public void switchOneHandedMode() {
-        mKeyboardViewWrapper.switchOneHandedModeSide();
-        Settings.getInstance().writeOneHandedModeGravity(mKeyboardViewWrapper.getOneHandedGravity());
-    }
-
-    @Override
-    public void setFloatingKeyboardEnabled(boolean enabled) {
-        if (enabled != Settings.getValues().mIsFloatingKeyboard)
-            // mIsFloatingKeyboard is always disabled when device is locked, and we shouldn't mess up the setting
-            SettingsKt.setFloatingKeyboardEnabled(mThemeContext, enabled);
-        if (enabled) FloatingKeyboardUtils.setFloating(mCurrentInputView);
-        else FloatingKeyboardUtils.disableFloating(mCurrentInputView);
-        setBackgroundGatheringIndicatorPosition();
     }
 
     public void toggleSplitKeyboardMode() {
@@ -613,16 +455,6 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
                 margin.topMargin = kb.mOccupiedHeight - KtxKt.dpToPx(16, mCurrentInputView.getResources());
             mBackgroundGatheringIndicator.setLayoutParams(mBackgroundGatheringIndicator.getLayoutParams());
         }
-    }
-
-    // Implements {@link KeyboardState.SwitchActions}.
-    @Override
-    public boolean popDoubleTapShiftKeyTimer() {
-        if (DEBUG_TIMER_ACTION) {
-            Log.d(TAG, "isInDoubleTapShiftKeyTimeout");
-        }
-        final MainKeyboardView keyboardView = getMainKeyboardView();
-        return keyboardView != null && keyboardView.popDoubleTapShiftKeyTimer();
     }
 
     /**
@@ -800,6 +632,169 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
             mLatinIME.showWindow(true);
         } catch (IllegalStateException e) {
             // in tests isInputViewShown returns true, but showWindow throws "IllegalStateException: Window token is not set yet."
+        }
+    }
+
+    // private SwitchActions implementation so e.g. setEmojiKeyboard can only be called via KeyboardState (avoid inconsistencies!)
+    private class SwitchActions implements KeyboardState.SwitchActions{
+        @Override
+        public void setAlphabetKeyboard(@NonNull ShiftMode shiftMode) {
+            if (DEBUG_ACTION) {
+                Log.d(TAG, "setAlphabetKeyboard");
+            }
+            setKeyboard(shiftMode.element, KeyboardSwitchState.OTHER);
+        }
+
+        @Override
+        public void setSymbolsKeyboard() {
+            if (DEBUG_ACTION) {
+                Log.d(TAG, "setSymbolsKeyboard");
+            }
+            setKeyboard(KeyboardElement.SYMBOLS, KeyboardSwitchState.OTHER);
+        }
+
+        @Override
+        public void setSymbolsShiftedKeyboard() {
+            if (DEBUG_ACTION) {
+                Log.d(TAG, "setSymbolsShiftedKeyboard");
+            }
+            setKeyboard(KeyboardElement.SYMBOLS_SHIFTED, KeyboardSwitchState.SYMBOLS_SHIFTED);
+        }
+
+        @Override
+        public void setEmojiKeyboard() {
+            if (DEBUG_ACTION) {
+                Log.d(TAG, "setEmojiKeyboard");
+            }
+            mMainKeyboardFrame.setVisibility(View.VISIBLE);
+            // The visibility of {@link #mKeyboardView} must be aligned with {@link #MainKeyboardFrame}.
+            // @see #getVisibleKeyboardView() and
+            // @see LatinIME#onComputeInset(android.inputmethodservice.InputMethodService.Insets)
+            mKeyboardView.setVisibility(View.GONE);
+            mSuggestionStripView.setVisibility(View.GONE);
+            mStripContainer.setVisibility(getSecondaryStripVisibility());
+            mClipboardStripScrollView.setVisibility(View.GONE);
+            mEmojiTabStripView.setVisibility(View.VISIBLE);
+            mClipboardHistoryView.setVisibility(View.GONE);
+            mEmojiPalettesView.startEmojiPalettes(mKeyboardView.getKeyVisualAttribute(),
+                mLatinIME.getCurrentInputEditorInfo(), mLatinIME.mKeyboardActionListener);
+            mEmojiPalettesView.setVisibility(View.VISIBLE);
+        }
+
+        @Override
+        public void setClipboardKeyboard() {
+            if (DEBUG_ACTION) {
+                Log.d(TAG, "setClipboardKeyboard");
+            }
+            mMainKeyboardFrame.setVisibility(View.VISIBLE);
+            // The visibility of {@link #mKeyboardView} must be aligned with {@link #MainKeyboardFrame}.
+            // @see #getVisibleKeyboardView() and
+            // @see LatinIME#onComputeInset(android.inputmethodservice.InputMethodService.Insets)
+            mKeyboardView.setVisibility(View.GONE);
+            mEmojiTabStripView.setVisibility(View.GONE);
+            mSuggestionStripView.setVisibility(View.GONE);
+            mStripContainer.setVisibility(getSecondaryStripVisibility());
+            mClipboardStripScrollView.post(() -> mClipboardStripScrollView.fullScroll(HorizontalScrollView.FOCUS_RIGHT));
+            mClipboardStripScrollView.setVisibility(View.VISIBLE);
+            mEmojiPalettesView.setVisibility(View.GONE);
+            mClipboardHistoryView.startClipboardHistory(mLatinIME.getClipboardHistoryManager(), mKeyboardView.getKeyVisualAttribute(),
+                mLatinIME.getCurrentInputEditorInfo(), mLatinIME.mKeyboardActionListener);
+            mClipboardHistoryView.setVisibility(View.VISIBLE);
+        }
+
+        @Override
+        public void setNumpadKeyboard() {
+            if (DEBUG_ACTION) {
+                Log.d(TAG, "setNumpadKeyboard");
+            }
+            setKeyboard(KeyboardElement.NUMPAD, KeyboardSwitchState.OTHER);
+        }
+
+        @Override
+        public void setDpadKeyboard() {
+            if (DEBUG_ACTION) {
+                Log.d(TAG, "setDpadKeyboard");
+            }
+            setKeyboard(KeyboardElement.DPAD, KeyboardSwitchState.OTHER);
+        }
+
+        @Override
+        public void startDoubleTapShiftKeyTimer() {
+            if (DEBUG_TIMER_ACTION) {
+                Log.d(TAG, "startDoubleTapShiftKeyTimer");
+            }
+            MainKeyboardView keyboardView = getMainKeyboardView();
+            if (keyboardView != null) {
+                keyboardView.startDoubleTapShiftKeyTimer();
+            }
+        }
+
+        @Override
+        public void cancelDoubleTapShiftKeyTimer() {
+            if (DEBUG_TIMER_ACTION) {
+                Log.d(TAG, "cancelDoubleTapShiftKeyTimer");
+            }
+            MainKeyboardView keyboardView = getMainKeyboardView();
+            if (keyboardView != null) {
+                keyboardView.cancelDoubleTapShiftKeyTimer();
+            }
+        }
+
+        @Override
+        public void setOneHandedModeEnabled(boolean enabled) {
+            KeyboardSwitcher.this.setOneHandedModeEnabled(enabled, false);
+        }
+
+        @Override
+        public void switchOneHandedMode() {
+            mKeyboardViewWrapper.switchOneHandedModeSide();
+            Settings.getInstance().writeOneHandedModeGravity(mKeyboardViewWrapper.getOneHandedGravity());
+        }
+
+        @Override
+        public void setFloatingKeyboardEnabled(boolean enabled) {
+            if (enabled != Settings.getValues().mIsFloatingKeyboard)
+                // mIsFloatingKeyboard is always disabled when device is locked, and we shouldn't mess up the setting
+                SettingsKt.setFloatingKeyboardEnabled(mThemeContext, enabled);
+            if (enabled) FloatingKeyboardUtils.setFloating(mCurrentInputView);
+            else FloatingKeyboardUtils.disableFloating(mCurrentInputView);
+            setBackgroundGatheringIndicatorPosition();
+        }
+
+        @Override
+        public boolean popDoubleTapShiftKeyTimer() {
+            if (DEBUG_TIMER_ACTION) {
+                Log.d(TAG, "isInDoubleTapShiftKeyTimeout");
+            }
+            MainKeyboardView keyboardView = getMainKeyboardView();
+            return keyboardView != null && keyboardView.popDoubleTapShiftKeyTimer();
+        }
+
+        // not a SwitchAction, but should only be called from a SwitchAction to avoid inconsistent state / actual layout
+        private void setKeyboard(KeyboardElement keyboardElement, @NonNull KeyboardSwitchState toggleState) {
+            // with a hardware keyboard we might get here without ever calling onCreateInputView, so don't crash
+            if (mKeyboardView == null) return;
+
+            // Make {@link MainKeyboardView} visible and hide {@link EmojiPalettesView}.
+            SettingsValues currentSettingsValues = Settings.getValues();
+            setMainKeyboardFrame(currentSettingsValues, toggleState);
+            // TODO: pass this object to setKeyboard instead of getting the current values.
+            MainKeyboardView keyboardView = mKeyboardView;
+            Keyboard oldKeyboard = keyboardView.getKeyboard();
+            Keyboard newKeyboard = mKeyboardLayoutSet.getKeyboard(keyboardElement);
+            keyboardView.setKeyboard(newKeyboard);
+            mCurrentInputView.setKeyboardTopPadding(newKeyboard.mTopPadding);
+            keyboardView.setKeyPreviewPopupEnabled(currentSettingsValues.mKeyPreviewPopupOn);
+            keyboardView.updateShortcutKey(mRichImm.isShortcutImeReady());
+            boolean subtypeChanged = (oldKeyboard == null) || !newKeyboard.mId.getSubtype().equals(oldKeyboard.mId.getSubtype());
+            int languageOnSpacebarFormatType = LanguageOnSpacebarUtils.getLanguageOnSpacebarFormatType(newKeyboard.mId.getSubtype());
+            boolean hasMultipleEnabledIMEsOrSubtypes = mRichImm.hasMultipleEnabledIMEsOrSubtypes(true);
+            keyboardView.startDisplayLanguageOnSpacebar(subtypeChanged, languageOnSpacebarFormatType, hasMultipleEnabledIMEsOrSubtypes);
+
+            if (currentSettingsValues.needsToLookupSuggestions()
+                && (currentSettingsValues.mInlineEmojiSearch || currentSettingsValues.mSuggestEmojis)) {
+                EmojiParserKt.loadEmojiDefaultVersionsAndPopupSpecs(mThemeContext);
+            }
         }
     }
 }

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
@@ -284,9 +284,9 @@ public final class KeyboardSwitcher {
         CLIPBOARD(KeyboardElement.CLIPBOARD),
         OTHER(null);
 
-        final KeyboardElement mKeyboardElement;
+        @Nullable final KeyboardElement mKeyboardElement;
 
-        KeyboardSwitchState(KeyboardElement keyboardElement) {
+        KeyboardSwitchState(@Nullable KeyboardElement keyboardElement) {
             mKeyboardElement = keyboardElement;
         }
     }
@@ -330,12 +330,10 @@ public final class KeyboardSwitcher {
 
                 mMainKeyboardFrame.setVisibility(View.VISIBLE);
                 mKeyboardView.setVisibility(View.VISIBLE);
-                // todo: this doesn't tell KeyboardState that this mode has been set.
-                //  example: if you press physical alt the more symbols keyboard will appear,
-                //  but if you then do 2 D-pad space swipes it'll return to alpha instead
-                //  because KeyboardState thinks the `mode` is alphabet when doing the
-                //  initial toggle.
-                setKeyboard(toggleState.mKeyboardElement, toggleState);
+                if (toggleState == KeyboardSwitchState.SYMBOLS_SHIFTED)
+                    // possible other states OTHER and HIDDEN have keyboardElement null, which we just ignore
+                    // might need to be adjusted when functionality is extended
+                    mState.setLayout(LayoutDirective.Utility.SYMBOLS_SHIFTED);
             }
         }
     }
@@ -636,7 +634,7 @@ public final class KeyboardSwitcher {
     }
 
     // private SwitchActions implementation so e.g. setEmojiKeyboard can only be called via KeyboardState (avoid inconsistencies!)
-    private class SwitchActions implements KeyboardState.SwitchActions{
+    private class SwitchActions implements KeyboardState.SwitchActions {
         @Override
         public void setAlphabetKeyboard(@NonNull ShiftMode shiftMode) {
             if (DEBUG_ACTION) {

--- a/app/src/main/java/helium314/keyboard/keyboard/emoji/EmojiSearchActivity.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/emoji/EmojiSearchActivity.kt
@@ -324,7 +324,7 @@ class EmojiSearchActivity : ComponentActivity() {
                     if (it.mHasShortcuts) it.mShortcutTargets[0]?.mWord else null
                 } else null
         })
-        KeyboardSwitcher.getInstance().setAlphabetKeyboard(ShiftMode.UNSHIFT)
+        KeyboardSwitcher.getInstance().resetKeyboardStateToAlphabet()
         Log.d(TAG, "init end")
     }
 

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/KeyboardState.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/KeyboardState.kt
@@ -183,6 +183,7 @@ class KeyboardState(private val switchActions: SwitchActions) {
             Utility.DPAD -> switchActions.setDpadKeyboard()
         }
         mode = layout.mode()
+        if (layout is Alphabet) shiftMode = layout.shiftMode
         recapitalizeMode = null
         isInSpaceToAlpha = false
         if (layout is Alphabet && layout.shiftMode == ShiftMode.AUTOMATIC) {

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/KeyboardState.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/KeyboardState.kt
@@ -39,11 +39,6 @@ class KeyboardState(private val switchActions: SwitchActions) {
         fun setDpadKeyboard()
         fun setSymbolsKeyboard()
         fun setSymbolsShiftedKeyboard()
-        fun toggleLayout(layout: Utility, autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?)
-        fun onLongPressAlphaSymbolForNumpad()
-
-        /** Request to call back [KeyboardState.onUpdateShiftState]. */
-        fun requestUpdatingShiftState(autoCapsFlags: Int, recapitalizeMode: RecapitalizeMode?)
 
         fun startDoubleTapShiftKeyTimer()
         fun popDoubleTapShiftKeyTimer(): Boolean
@@ -109,7 +104,7 @@ class KeyboardState(private val switchActions: SwitchActions) {
         } else {
             // Reset keyboard to alphabet mode.
             loadLayout(Alphabet(ShiftMode.UNSHIFT, autoCapsFlags, recapitalizeMode))
-            switchActions.requestUpdatingShiftState(autoCapsFlags, recapitalizeMode)
+            onUpdateShiftState(autoCapsFlags, recapitalizeMode)
         }
         switchActions.setOneHandedModeEnabled(onHandedModeEnabled)
         switchActions.setFloatingKeyboardEnabled(Settings.getValues().mIsFloatingKeyboard)
@@ -150,11 +145,7 @@ class KeyboardState(private val switchActions: SwitchActions) {
         }
         prevLayouts.wipe()
         if (mode == Mode.ALPHABET) {
-            // todo
-            //  Currently we want to always load the alphabet keyboard, because KeyboadSwitcher.setEmojiKeyboard (and others)
-            //  might be called from other places than KeyboardState, in which case we have the wrong mode and prevLayouts.
-            //  a proper fix would be to either check the state in all SwitchActions, or make sure they are only called from KeyboardState.
-            //return
+            return
         }
         loadLayout(Alphabet(shiftMode, autoCapsFlags, recapitalizeMode))
     }
@@ -164,7 +155,7 @@ class KeyboardState(private val switchActions: SwitchActions) {
         setLayout(layout)
     }
 
-    private fun setLayout(layout: LayoutDirective) {
+    fun setLayout(layout: LayoutDirective) {
         prevLayouts.push(mode)
         loadLayout(layout)
     }
@@ -187,7 +178,7 @@ class KeyboardState(private val switchActions: SwitchActions) {
         recapitalizeMode = null
         isInSpaceToAlpha = false
         if (layout is Alphabet && layout.shiftMode == ShiftMode.AUTOMATIC) {
-            switchActions.requestUpdatingShiftState(layout.autoCapsFlags, layout.recapitalizeMode)
+            onUpdateShiftState(layout.autoCapsFlags, layout.recapitalizeMode)
         }
     }
 
@@ -422,7 +413,7 @@ class KeyboardState(private val switchActions: SwitchActions) {
                     ShiftMode.LOCKED -> {}
                 }
                 // Automatic shift state may have been changed depending on what characters were input.
-                switchActions.requestUpdatingShiftState(autoCapsFlags, recapitalizeMode)
+                onUpdateShiftState(autoCapsFlags, recapitalizeMode)
                 return
             }
             if (withSliding) {

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/ShiftMode.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/ShiftMode.kt
@@ -3,8 +3,12 @@ package helium314.keyboard.keyboard.internal
 import helium314.keyboard.keyboard.KeyboardElement
 
 enum class ShiftMode(@JvmField val element: KeyboardElement) {
+    /** shift disabled */
     UNSHIFT(KeyboardElement.ALPHABET),
+    /** shift was enabled by the user */
     MANUAL(KeyboardElement.ALPHABET_MANUAL_SHIFTED),
+    /** shift was enabled automatically */
     AUTOMATIC(KeyboardElement.ALPHABET_AUTOMATIC_SHIFTED),
+    /** shift locked */
     LOCKED(KeyboardElement.ALPHABET_SHIFT_LOCKED),
 }

--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -241,7 +241,7 @@ public class LatinIME extends InputMethodService implements
                             latinIme.mSettings.getCurrent(), msg.arg1 /* inputStyle */);
                     break;
                 case MSG_UPDATE_SHIFT_STATE:
-                    latinIme.mKeyboardSwitcher.requestUpdatingShiftState(latinIme.getCurrentAutoCapsState(),
+                    latinIme.mKeyboardSwitcher.updateShiftState(latinIme.getCurrentAutoCapsState(),
                             latinIme.getCurrentRecapitalizeState());
                     break;
                 case MSG_SHOW_GESTURE_PREVIEW_AND_SET_SUGGESTIONS:
@@ -972,12 +972,12 @@ public class LatinIME extends InputMethodService implements
         } else if (restarting) {
             // TODO: Come up with a more comprehensive way to reset the keyboard layout when
             // a keyboard layout set doesn't get reloaded in this method.
-            switcher.resetKeyboardStateToAlphabet(getCurrentAutoCapsState(), getCurrentRecapitalizeState());
+            switcher.resetKeyboardStateToAlphabet();
             // In apps like Talk, we come here when the text is sent and the field gets emptied and
             // we need to re-evaluate the shift state, but not the whole layout which would be
             // disruptive.
             // Space state must be updated before calling updateShiftState
-            switcher.requestUpdatingShiftState(getCurrentAutoCapsState(), getCurrentRecapitalizeState());
+            switcher.updateShiftState(getCurrentAutoCapsState(), getCurrentRecapitalizeState());
         }
         // Set neutral suggestions and show the toolbar if the "Auto show toolbar" setting is enabled.
         if (!mHandler.hasPendingResumeSuggestions()) {
@@ -1076,7 +1076,7 @@ public class LatinIME extends InputMethodService implements
             if (mKeyboardSwitcher.getKeyboard() != null && mKeyboardSwitcher.getKeyboard().mId.getElement().isAlphabetShiftedManually()
                 && ((oldSelEnd == newSelEnd && oldSelStart != newSelStart) || (oldSelEnd != newSelEnd && oldSelStart == newSelStart)))
                 return;
-            mKeyboardSwitcher.requestUpdatingShiftState(getCurrentAutoCapsState(), getCurrentRecapitalizeState());
+            mKeyboardSwitcher.updateShiftState(getCurrentAutoCapsState(), getCurrentRecapitalizeState());
         }
     }
 
@@ -1619,7 +1619,7 @@ public class LatinIME extends InputMethodService implements
         switch (inputTransaction.getRequiredShiftUpdate()) {
             case InputTransaction.SHIFT_UPDATE_LATER -> mHandler.postUpdateShiftState();
             case InputTransaction.SHIFT_UPDATE_NOW -> mKeyboardSwitcher
-                    .requestUpdatingShiftState(getCurrentAutoCapsState(), getCurrentRecapitalizeState());
+                    .updateShiftState(getCurrentAutoCapsState(), getCurrentRecapitalizeState());
             default -> {
             } // SHIFT_NO_UPDATE
         }

--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -604,7 +604,7 @@ public final class InputLogic {
                 // after typing some letters and a period, then gesturing; the keyboard is not in
                 // caps mode yet, but since a gesture is starting, it should go in caps mode,
                 // unless the user explicitly said it should not.
-                keyboardSwitcher.requestUpdatingShiftState(getCurrentAutoCapsState(settingsValues), getCurrentRecapitalizeState());
+                keyboardSwitcher.updateShiftState(getCurrentAutoCapsState(settingsValues), getCurrentRecapitalizeState());
             }
         }
         mConnection.endBatchEdit();
@@ -2344,7 +2344,7 @@ public final class InputLogic {
         // Space state must be updated before calling updateShiftState
         if (settingsValues.mAutospaceAfterGestureTyping)
             mSpaceState = SpaceState.PHANTOM;
-        keyboardSwitcher.requestUpdatingShiftState(getCurrentAutoCapsState(settingsValues), getCurrentRecapitalizeState());
+        keyboardSwitcher.updateShiftState(getCurrentAutoCapsState(settingsValues), getCurrentRecapitalizeState());
 
         if (isInlineEmojiSearchAction()) {
             searchForEmojiInline(SuggestedWords.NOT_A_SEQUENCE_NUMBER, mLatinIME::setSuggestions);

--- a/app/src/test/java/helium314/keyboard/latin/InputLogicTest.kt
+++ b/app/src/test/java/helium314/keyboard/latin/InputLogicTest.kt
@@ -959,7 +959,7 @@ class ShadowKeyboardSwitcher {
     fun setKeyboard(keyboardId: Int, toggleState: KeyboardSwitcher.KeyboardSwitchState) = Unit
     @Implementation
     // only affects view
-    fun setOneHandedModeEnabled(enabled: Boolean) = Unit
+    fun setOneHandedModeEnabled(enabled: Boolean, force: Boolean) = Unit
     @Implementation
     fun getCurrentKeyboardScript() = currentScript
 }


### PR DESCRIPTION
To avoid inconsistent states that result in switches not happening any more.
See #2786 and https://github.com/HeliBorg/HeliBoard/pull/2648#issuecomment-5467402145.

`KeyboardState.SwitchActions` implementations in `KeyboardSwitcher` can now only be called by `KeyboardState`, which should avoid further such problems.
I removed some `KeyboardState.SwitchActions` because they were just calling `KeyboardState`, and 2 of the 3 were not used in `KeyboardState` at all.

Draft because something needs to be done about `setKeyboard(toggleState.mKeyboardElement, toggleState)`, because `setKeyboard` can now only be called from the `KeyboardState.SwitchActions` implementation.